### PR TITLE
Respect keep-going flag for async operations

### DIFF
--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -382,14 +382,14 @@ class BackupLayout:
 
         self._delete_files(deleting_files)
 
-    def wait(self) -> None:
+    def wait(self, keep_going: bool = False) -> None:
         """
         Wait for completion of data upload and download.
         """
         try:
             logging.memory_usage()
-            logging.debug('Waiting for completion of async operations')
-            self._storage_loader.wait()
+            logging.debug(f'Waiting for completion of async operations with keep_going={keep_going}')
+            self._storage_loader.wait(keep_going)
         except Exception as e:
             raise StorageError('Failed to complete async operations') from e
 

--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -443,7 +443,7 @@ class TableBackup(BackupManager):
                         else:
                             raise
 
-                context.backup_layout.wait()
+                context.backup_layout.wait(keep_going)
 
                 context.ch_ctl.chown_detached_table_parts(table, context.restore_context)
                 for part in attach_parts:

--- a/ch_backup/storage/async_pipeline/pipeline_executor.py
+++ b/ch_backup/storage/async_pipeline/pipeline_executor.py
@@ -114,12 +114,12 @@ class PipelineExecutor:
         pipeline = partial(delete_multiple_storage_pipeline, self._config, remote_paths)
         self._exec_pipeline(job_id, pipeline, is_async)
 
-    def wait(self) -> None:
+    def wait(self, keep_going: bool = False) -> None:
         """
         Wait for completion of async operations.
         """
         if self._exec_pool:
-            self._exec_pool.wait_all()
+            self._exec_pool.wait_all(keep_going)
 
     def _exec_pipeline(self, job_id: str, pipeline: Callable, is_async: bool) -> Any:
         """

--- a/ch_backup/storage/loader.py
+++ b/ch_backup/storage/loader.py
@@ -110,11 +110,11 @@ class StorageLoader:
         """
         self._ploader.delete_files(remote_paths, is_async=is_async, encryption=encryption)
 
-    def wait(self) -> None:
+    def wait(self, keep_going: bool = False) -> None:
         """
         Wait for completion of async operations.
         """
-        self._ploader.wait()
+        self._ploader.wait(keep_going)
 
     def list_dir(self, remote_path: str, recursive: bool = False, absolute: bool = False) -> Sequence[str]:
         """

--- a/tests/integration/features/backup_restore.feature
+++ b/tests/integration/features/backup_restore.feature
@@ -132,9 +132,6 @@ Feature: Backup & Restore
     INSERT INTO test_db.test_table SELECT number % 2, number FROM system.numbers LIMIT 100;
     """
     And we create clickhouse01 clickhouse backup
-    Then we got the following backups on clickhouse01
-      | num | state    | data_count | link_count   |
-      | 0   | created  | 2          | 0            |
     Given ch-backup configuration on clickhouse02
     """
     backup:

--- a/tests/integration/modules/ch_backup.py
+++ b/tests/integration/modules/ch_backup.py
@@ -280,20 +280,23 @@ class BackupManager:
         return Backup(json.loads(output))
 
     # pylint: disable=too-many-arguments
-    def restore(self,
-                backup_id: BackupId,
-                schema_only: bool = False,
-                override_replica_name: str = None,
-                force_non_replicated: bool = False,
-                clean_zookeeper: bool = False,
-                replica_name: str = None,
-                cloud_storage_source_bucket: str = None,
-                cloud_storage_source_path: str = None,
-                cloud_storage_latest: bool = False,
-                access: bool = None,
-                data: bool = None,
-                schema: bool = None,
-                udf: bool = None) -> str:
+    def restore(
+        self,
+        backup_id: BackupId,
+        schema_only: bool = False,
+        override_replica_name: str = None,
+        force_non_replicated: bool = False,
+        clean_zookeeper: bool = False,
+        replica_name: str = None,
+        cloud_storage_source_bucket: str = None,
+        cloud_storage_source_path: str = None,
+        cloud_storage_latest: bool = False,
+        access: bool = None,
+        data: bool = None,
+        schema: bool = None,
+        udf: bool = None,
+        keep_going: bool = False,
+    ) -> str:
         """
         Restore backup entry.
         """
@@ -323,6 +326,8 @@ class BackupManager:
             options.append('--schema')
         if udf:
             options.append('--udf')
+        if keep_going:
+            options.append('--keep-going')
         return self._exec(f'restore {" ".join(options)} {backup_id}')
 
     def restore_access_control(self, backup_id: BackupId) -> str:


### PR DESCRIPTION
Respect `--keep-going` flag for async operations. 
This is useful when we want to not stop the restore operation if any error occurs during it. We get the failed restore with the following trace log in a such case:
```
 Traceback (most recent call last):
    File "/usr/lib/python3.6/concurrent/futures/process.py", line 175, in _process_worker
      r = call_item.fn(*call_item.args, **call_item.kwargs)
    File "/var/tmp/ch-backup/ch_backup/storage/async_pipeline/pipelines.py", line 108, in download_files_pipeline
      run(builder.pipeline())
    File "/var/tmp/ch-backup/ch_backup/storage/async_pipeline/pipelines.py", line 127, in run
      exhaust_iterator(itr)
    File "/var/tmp/ch-backup/ch_backup/util.py", line 291, in exhaust_iterator
      collections.deque(iterator, maxlen=0)
    File "/usr/local/lib/python3.6/dist-packages/pypeln/thread/stage.py", line 82, in to_iterable
      for elem in main_queue:
    File "/usr/local/lib/python3.6/dist-packages/pypeln/thread/queue.py", line 87, in __iter__
      x = self.get(timeout=pypeln_utils.TIMEOUT)
    File "/usr/local/lib/python3.6/dist-packages/pypeln/thread/queue.py", line 36, in get
      raise exception
  nacl.exceptions.CryptoError: 
  
  ('Decryption failed. Ciphertext failed verification',)
```
