### PR TITLE
Update max version of PyYAML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ requests>2.19
 boto3<1.19
 botocore<1.22
 psutil
-PyYAML<6
+PyYAML<5.4
 PyNaCl==1.2.1
 click
 cloup


### PR DESCRIPTION
It fixes the following error in `main` branch:
```
$ make format
if [ -z "" ]; then python3 -m venv venv; fi
env PATH=venv/bin:/Users/alex-burmak/mdb-scripts/bin:/Users/alex-burmak/ycp/bin:/Users/alex-burmak/yandex-cloud/bin:/Users/alex-burmak/yandex-cloud/bin:/usr/local/opt/grep/libexec/gnubin:/usr/local/opt/gnu-sed/libexec/gnubin:/usr/local/opt/findutils/libexec/gnubin:/usr/local/opt/coreutils/libexec/gnubin:/Users/alex-burmak/bin.d/mdb-scripts:/Users/alex-burmak/bin.d/tools:/Users/alex-burmak/bin:/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/munki:/Users/alex-burmak/go/bin PYTHONIOENCODING=utf8 CLICKHOUSE_VERSION=23.3.7.5 COMPOSE_HTTP_TIMEOUT=300 pip install --no-cache-dir --disable-pip-version-check -r requirements.txt -r requirements-dev.txt
Ignoring dataclasses: markers 'python_version < "3.7"' don't match your environment
Ignoring typing_extensions: markers 'python_version < "3.8"' don't match your environment
Collecting requests>2.19
  Downloading requests-2.31.0-py3-none-any.whl (62 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 62.6/62.6 kB 1.5 MB/s eta 0:00:00
Collecting boto3<1.19
  Downloading boto3-1.18.65-py3-none-any.whl (131 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 131.7/131.7 kB 3.5 MB/s eta 0:00:00
Collecting botocore<1.22
  Downloading botocore-1.21.65-py3-none-any.whl (8.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.0/8.0 MB 6.9 MB/s eta 0:00:00
Collecting psutil
  Downloading psutil-5.9.5-cp36-abi3-macosx_10_9_x86_64.whl (245 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 245.3/245.3 kB 7.9 MB/s eta 0:00:00
Collecting PyYAML<6
  Downloading PyYAML-5.4.1.tar.gz (175 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 175.1/175.1 kB 4.7 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [62 lines of output]
      /private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
      !!

              ********************************************************************************
              The license_file parameter is deprecated, use license_files instead.

              By 2023-Oct-30, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.

              See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
              ********************************************************************************

      !!
        parsed = self.parsers.get(option_name, lambda x: x)(value)
      running egg_info
      writing lib3/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib3/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib3/PyYAML.egg-info/top_level.txt
      Traceback (most recent call last):
        File "/Users/alex-burmak/workspace/repos/ya/ch-backup/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/Users/alex-burmak/workspace/repos/ya/ch-backup/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/Users/alex-burmak/workspace/repos/ya/ch-backup/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 341, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 323, in _get_build_requires
          self.run_setup()
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 338, in run_setup
          exec(code, locals())
        File "<string>", line 271, in <module>
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/__init__.py", line 107, in setup
          return distutils.core.setup(**attrs)
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 185, in setup
          return run_commands(dist)
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
          dist.run_commands()
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/dist.py", line 1234, in run_command
          super().run_command(command)
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 314, in run
          self.find_sources()
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 322, in find_sources
          mm.run()
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 551, in run
          self.add_defaults()
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 589, in add_defaults
          sdist.add_defaults(self)
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/command/sdist.py", line 104, in add_defaults
          super().add_defaults()
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/_distutils/command/sdist.py", line 251, in add_defaults
          self._add_defaults_ext()
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/_distutils/command/sdist.py", line 336, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
        File "<string>", line 201, in get_source_files
        File "/private/var/folders/bz/df0k3csx3r34yy2gr0521g49gxnr28/T/pip-build-env-go49kirc/overlay/lib/python3.10/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
make: *** [.install-deps] Error 1
```