### PR TITLE
Docker Compose v2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,9 +14,7 @@ pytest
 PyHamcrest==2.0.0
 hypothesis
 behave
-docker<5.0
-docker-compose<1.28
-websocket-client<1.0  # required for docker-compose<1.28
+docker
 Jinja2
 deepdiff<5.8
 mypy-boto3-s3==1.21.7  # this is the last version that requires typing-extensions<4.0.0

--- a/tests/integration/modules/compose.py
+++ b/tests/integration/modules/compose.py
@@ -182,7 +182,7 @@ def _call_compose(conf: dict, *, command: str, project_name: str = None) -> None
     """
     Execute docker-compose action by invoking `docker-compose`.
     """
-    shell_command = f"docker-compose --file {_config_path(conf)}"
+    shell_command = f"docker compose --file {_config_path(conf)}"
     if project_name:
         shell_command += f" -p {project_name}"
     shell_command += f" {command}"


### PR DESCRIPTION
- Add support of Docker Compose v2
- Drop support and usage of deprecated Docker Compose v1

https://docs.docker.com/compose/migrate/