### PR TITLE
Actualize supporting options in integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,5 +201,7 @@ help:
 	@echo "  PYTHON                     Python executable to use (default: \"$(PYTHON)\")."
 	@echo "  PYTEST_ARGS                Arguments to pass to pytest (unit tests)."
 	@echo "  BEHAVE_ARGS                Arguments to pass to behave (integration tests)."
+	@echo "                             Project-specific behave options:"
+	@echo "                               -D no_stop_on_fail  Keep Docker containers running on test failure."
 	@echo "  NO_VENV                    Disable creation of venv if the variable is set to non-empty value."
 	@echo "  CLICKHOUSE_VERSION         ClickHouse version to use in integration tests (default: \"$(CLICKHOUSE_VERSION)\")."

--- a/tests/integration/environment.py
+++ b/tests/integration/environment.py
@@ -8,11 +8,6 @@ from tests.integration import env_control
 from tests.integration.modules.logs import save_logs
 from tests.integration.modules.utils import version_ge, version_lt
 
-try:
-    import ipdb as pdb
-except ImportError:
-    import pdb  # type: ignore
-
 
 def before_all(context):
     """
@@ -50,16 +45,18 @@ def after_step(context, step):
     """
     if step.status == "failed":
         save_logs(context)
-        if context.config.userdata.getbool("debug"):
-            pdb.post_mortem(step.exc_traceback)
 
 
 def after_all(context):
     """
     Top-level cleanup function.
     """
-    if context.failed and not context.aborted:
-        logging.warning("Remember to run `make clean` after you done")
+    if (
+        context.failed
+        and not context.aborted
+        and context.config.userdata.getbool("no_stop_on_fail")
+    ):
+        logging.info("Not stopping containers on failure as requested")
         return
     env_control.stop(context)
 


### PR DESCRIPTION
- Add `-D no_stop_on_fail`
- Drop broken `-D debug`
- Document supporting options in `make help`