### PR TITLE
Unify naming of Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,17 +61,17 @@ test-unit: build
 
 
 .PHONY: test-integration
-test-integration: build create_env
+test-integration: build create-env
 	rm -rf staging/logs
 	${TEST_ENV} behave --show-timings --stop -D skip_setup $(BEHAVE_ARGS) @tests/integration/ch_backup.featureset
 
 
 .PHONY: clean
-clean: clean_env clean_pycache
+clean: clean-env clean-pycache
 	rm -rf venv *.egg-info htmlcov .coverage* .hypothesis .mypy_cache .pytest_cache .install-deps ch_backup/version.txt
 
-.PHONY: clean_pycache
-clean_pycache:
+.PHONY: clean-pycache
+clean-pycache:
 	find . -name __pycache__ -type d -exec rm -rf {} +
 
 
@@ -102,43 +102,43 @@ uninstall:
 
 
 .PHONY: debuild
-debuild: debian_changelog
+debuild: debian-changelog
 	cd debian && \
 	    debuild --check-dirname-level 0 --no-tgz-check --preserve-env -uc -us
 
-.PHONY: debian_changelog
-debian_changelog: build
+.PHONY: debian-changelog
+debian-changelog: build
 	@rm -f debian/changelog
 	dch --create --package ch-backup --distribution stable \
 	    -v `cat ch_backup/version.txt` \
 	    "Yandex autobuild"
 
 
-.PHONY: clean_debuild
-clean_debuild: clean
+.PHONY: clean-debuild
+clean-debuild: clean
 	rm -rf debian/{changelog,files,ch-backup*}
 	rm -f ../ch-backup_*{build,changes,deb,dsc,tar.gz}
 
 
-.PHONY: create_env
-create_env: build ${SESSION_FILE}
+.PHONY: create-env
+create-env: build ${SESSION_FILE}
 
 ${SESSION_FILE}:
 	${INTEGRATION_TEST_TOOL} create
 
 
-.PHONY: start_env
-start_env: create_env
+.PHONY: start-env
+start-env: create-env
 	${INTEGRATION_TEST_TOOL} start
 
 
-.PHONY: stop_env
-stop_env:
+.PHONY: stop-env
+stop-env:
 	test -f ${SESSION_FILE} && ${INTEGRATION_TEST_TOOL} stop || true
 
 
-.PHONY: clean_env
-clean_env: stop_env
+.PHONY: clean-env
+clean-env: stop-env
 	rm -rf staging ${SESSION_FILE}
 
 
@@ -176,12 +176,12 @@ help:
 	@echo "  mypy                       Perform mypy checks.."
 	@echo "  bandit                     Perform bandit checks."
 	@echo "  clean                      Clean up build and test artifacts."
-	@echo "  create_env                 Create test environment."
-	@echo "  start_env                  Start test environment runtime."
-	@echo "  stop_env                   Stop test environment runtime."
-	@echo "  clean_env                  Clean up test environment."
+	@echo "  create-env                 Create test environment."
+	@echo "  start-env                  Start test environment runtime."
+	@echo "  stop-env                   Stop test environment runtime."
+	@echo "  clean-env                  Clean up test environment."
 	@echo "  debuild                    Build Debian package."
-	@echo "  clean_debuild              Clean up build and test artifacts including ones produced by"
+	@echo "  clean-debuild              Clean up build and test artifacts including ones produced by"
 	@echo "                             debuild target outside the project worksapce."
 	@echo "  format                     Re-format source code to conform style settings enforced by"
 	@echo "                             isort and black tools."

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following steps describe how to set up testing infrastructure on top of
 
 1. Create and run docker containers.
 ```
-$ make start_env
+$ make start-env
 ...
 Creating minio01.test_net_711 ...
 Creating clickhouse01.test_net_711 ...
@@ -108,9 +108,9 @@ make all
 Unit tests are implemented based on [pytest](https://docs.pytest.org/en/latest/) testing framework.
 
 The tests can be run as a part of regression test suite with `make all` or
-separately with `make unit_test`. Additionally, `PYTEST_ARGS` parameter
+separately with `make test-unit`. Additionally, `PYTEST_ARGS` parameter
 can be used to pass additional arguments to underlying `py.test` invocation.
-For example, `make unit_tests PYTES_ARGS='-k dedup'` executes only deduplication-realted tests.
+For example, `make test-unit PYTES_ARGS='-k dedup'` executes only deduplication-realted tests.
 
 ### Integration tests
 
@@ -119,7 +119,7 @@ Integration tests verify ch-backup functionality in isolated virtual environment
 [Behave](https://behave.readthedocs.io/en/stable/) as a testing framework.
 
 The tests can be run as a part of regression test suite with `make all` or
-separately with `make integration_test`. Additionally, `BEHAVE_ARGS` parameter
+separately with `make test-integration`. Additionally, `BEHAVE_ARGS` parameter
 can be used to pass additional arguments to underlying `behave` invocation.
-For example, `make integration_test BEHAVE_ARGS='-i ssl_support'` executes
+For example, `make test-integration BEHAVE_ARGS='-i ssl_support'` executes
 tests that belongs to SSL support feature (`ssl_support.feature`).


### PR DESCRIPTION
Use `-` as word separator in all target names. Previously it was used both `_` and `-` as word separators.