### PR TITLE
Upload logs and diagnostics data on Integration test failure

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -60,3 +60,9 @@ jobs:
       run: make test-unit
     - name: run integration tests
       run: CLICKHOUSE_VERSION=${{ matrix.clickhouse }} make test-integration
+    - uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: integration-test-logs-py${{ matrix.target.python }}-clickhouse-${{ matrix.clickhouse }}
+        path: staging/logs/
+        if-no-files-found: ignore


### PR DESCRIPTION
Example of artifacts with integration test logs:
https://github.com/yandex/ch-backup/actions/runs/5800651781?pr=37