### PR TITLE
Disable needless kazoo logging in integration tests

### DIFF
--- a/tests/integration/modules/zookeeper.py
+++ b/tests/integration/modules/zookeeper.py
@@ -1,7 +1,7 @@
 """
 ZooKeeper client calls
 """
-
+import logging
 from typing import List, Optional
 
 from kazoo.client import KazooClient
@@ -59,6 +59,9 @@ def get_children_list(context: ContextT, node: str, zk_path: str) -> Optional[Li
 
 
 def _get_zookeeper_client(context: ContextT, node: str) -> KazooClient:
+    # disable logging
+    logging.getLogger("kazoo").setLevel(logging.CRITICAL)
+
     zk_container = get_container(context, node)
     host, port = get_exposed_port(zk_container, 2181)
     return KazooClient(f"{host}:{port}")


### PR DESCRIPTION
To avoid adding needless information to behave output.

```
  Scenario: check ZK data after restore to replicated storage                                 # tests/integration/features/access_control_replicated_backup.feature:58
    Given default configuration                                                               # tests/integration/steps/common.py:12
    And a working s3                                                                          # tests/integration/steps/s3.py:11
    And a working zookeeper on zookeeper01                                                    # tests/integration/steps/zookeeper.py:13
INFO:kazoo.client:Connecting to 127.0.0.1(127.0.0.1):32833, use_ssl: False
WARNING:kazoo.client:Connection dropped: socket connection error: Connection reset by peer
INFO:kazoo.client:Connecting to 127.0.0.1(127.0.0.1):32833, use_ssl: False
WARNING:kazoo.client:Connection dropped: socket connection broken
INFO:kazoo.client:Connecting to 127.0.0.1(127.0.0.1):32833, use_ssl: False
WARNING:kazoo.client:Connection dropped: socket connection broken
INFO:kazoo.client:Connecting to 127.0.0.1(127.0.0.1):32833, use_ssl: False
INFO:kazoo.client:Zookeeper connection established, state: CONNECTED
INFO:kazoo.client:Closing connection to 127.0.0.1:32833
INFO:kazoo.client:Zookeeper session closed, state: CLOSED
...
      Captured logging:
      INFO:kazoo.client:Connecting to 127.0.0.1(127.0.0.1):32833, use_ssl: False
      WARNING:kazoo.client:Connection dropped: socket connection error: Connection reset by peer
      INFO:kazoo.client:Connecting to 127.0.0.1(127.0.0.1):32833, use_ssl: False
      WARNING:kazoo.client:Connection dropped: socket connection broken
      INFO:kazoo.client:Connecting to 127.0.0.1(127.0.0.1):32833, use_ssl: False
      WARNING:kazoo.client:Connection dropped: socket connection broken
      INFO:kazoo.client:Connecting to 127.0.0.1(127.0.0.1):32833, use_ssl: False
      INFO:kazoo.client:Zookeeper connection established, state: CONNECTED
      INFO:kazoo.client:Closing connection to 127.0.0.1:32833
      INFO:kazoo.client:Zookeeper session closed, state: CLOSED
      INFO:kazoo.client:Connecting to 127.0.0.1(127.0.0.1):32833, use_ssl: False
      INFO:kazoo.client:Zookeeper connection established, state: CONNECTED
      INFO:kazoo.client:Closing connection to 127.0.0.1:32833
      INFO:kazoo.client:Zookeeper session closed, state: CLOSED
      INFO:kazoo.client:Connecting to 127.0.0.1(127.0.0.1):32833, use_ssl: False
      INFO:kazoo.client:Zookeeper connection established, state: CONNECTED
      INFO:kazoo.client:Closing connection to 127.0.0.1:32833
      INFO:kazoo.client:Zookeeper session closed, state: CLOSED
      INFO:kazoo.client:Connecting to 127.0.0.1(127.0.0.1):32833, use_ssl: False
      INFO:kazoo.client:Zookeeper connection established, state: CONNECTED
      INFO:kazoo.client:Closing connection to 127.0.0.1:32833
      INFO:kazoo.client:Zookeeper session closed, state: CLOSED
      INFO:kazoo.client:Connecting to 127.0.0.1(127.0.0.1):32833, use_ssl: False
      INFO:kazoo.client:Zookeeper connection established, state: CONNECTED
      INFO:kazoo.client:Closing connection to 127.0.0.1:32833
      INFO:kazoo.client:Zookeeper session closed, state: CLOSED
      INFO:kazoo.client:Connecting to 127.0.0.1(127.0.0.1):32833, use_ssl: False
      INFO:kazoo.client:Zookeeper connection established, state: CONNECTED
      INFO:kazoo.client:Closing connection to 127.0.0.1:32833
      INFO:kazoo.client:Zookeeper session closed, state: CLOSED
      INFO:kazoo.client:Connecting to 127.0.0.1(127.0.0.1):32833, use_ssl: False
      INFO:kazoo.client:Zookeeper connection established, state: CONNECTED
      INFO:kazoo.client:Closing connection to 127.0.0.1:32833
      INFO:kazoo.client:Zookeeper session closed, state: CLOSED
```

https://github.com/yandex/ch-backup/actions/runs/5818401051/job/15774770223?pr=31