### PR TITLE
Latest backup in any state should not be deleted while partial delete command

### DIFF
--- a/ch_backup/ch_backup.py
+++ b/ch_backup/ch_backup.py
@@ -334,13 +334,15 @@ class ClickhouseBackup:
         found = False
         deleting_backups = []
         retained_backups = []
-        for backup in self._context.backup_layout.get_backups(use_light_meta=True):
+        for i, backup in enumerate(
+            self._context.backup_layout.get_backups(use_light_meta=True)
+        ):
             if backup.name == backup_name:
                 deleting_backups.append(backup)
                 found = True
                 continue
 
-            if purge_partial and backup.state != BackupState.CREATED:
+            if purge_partial and backup.state != BackupState.CREATED and i != 0:
                 deleting_backups.append(backup)
             else:
                 retained_backups.append(backup)

--- a/tests/integration/features/lock.feature
+++ b/tests/integration/features/lock.feature
@@ -1,0 +1,61 @@
+Feature: Lock
+
+  Background:
+    Given default configuration
+    And a working s3
+    And a working zookeeper on zookeeper01
+    And a working clickhouse on clickhouse01
+    And a working clickhouse on clickhouse02
+
+  @require_version_22.3
+  Scenario: No backup created while zk lock
+    When ch-backup configuration on clickhouse01
+    """
+    backup:
+        skip_lock_for_schema_only:
+            backup: false
+    lock:
+        zk_flock: true
+        zk_flock_path: /ch_backup/zk_flock_path
+    """
+    And on zookeeper01 we create /ch_backup/zk_flock_path
+    When we create clickhouse01 clickhouse backup
+    Then we got no backups on clickhouse01
+
+  @require_version_22.3
+  Scenario: No "schema-only" backup created while zk lock
+    When ch-backup configuration on clickhouse01
+    """
+    backup:
+        skip_lock_for_schema_only:
+            backup: false
+    lock:
+        zk_flock: true
+        zk_flock_path: /ch_backup/zk_flock_path
+    """
+    And on zookeeper01 we create /ch_backup/zk_flock_path
+    When we create clickhouse01 clickhouse backup
+    """
+    schema_only: true
+    """
+    Then we got no backups on clickhouse01
+
+  @require_version_22.3
+  Scenario: Skip zk lock while creating "schema-only" backup
+    When ch-backup configuration on clickhouse01
+    """
+    backup:
+        skip_lock_for_schema_only:
+            backup: true
+    lock:
+        zk_flock: true
+        zk_flock_path: /ch_backup/zk_flock_path
+    """
+    And on zookeeper01 we create /ch_backup/zk_flock_path
+    When we create clickhouse01 clickhouse backup
+    """
+    schema_only: true
+    """
+    Then we got the following backups on clickhouse01
+      | num | state   | schema_only |
+      | 0   | created | True        |

--- a/tests/integration/steps/ch_backup.py
+++ b/tests/integration/steps/ch_backup.py
@@ -118,6 +118,11 @@ def step_backup_metadata_absent(context, node, backup_id):
     assert_that(backup.meta, not has_entries(expected_meta))
 
 
+@then("we got no backups on {node:w}")
+def step_no_backups(context, node):
+    step_check_backups_conditions(context, node)
+
+
 @then("we got the following backups on {node:w}")
 def step_check_backups_conditions(context, node):
     ch_backup = BackupManager(context, node)


### PR DESCRIPTION
**Example:**
```      
backup100 CREATING
backup99 CREATED
backup98 FAILED
...
backup0 CREATED
```

`backup100` - newest
`backup0` - oldest

**Given:**
We want to delete oldest one, but backup100 is still creating.

**Actions:**
- we run `ch-backup delete --purge-partial backup0`
- we compute `deleting_backups` and `retained_backups` and collect deduplication data
- `backup100`'s metadata is loaded with `state=CREATING`, so we think it could be deleted/partially deleted as well
- while we downloading **other** backups metadata (it could take a while) `backup0` is changing state to `CREATED`
- delete command finishes metadata downloading
- `backup100` will be deleted, but it was created right now

**Fix**
Skip newest backup while purge-partial flag in delete command.

Btw, lock on backup and delete commands does not help there because metadata loading works outside of lock scope.
Also newest backup could be useful for future's backups because of deduplication.
