### PR TITLE
Fix DeepDiff dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,4 +19,4 @@ docker<5.0
 docker-compose<1.28
 websocket-client<1.0  # required for docker-compose<1.28
 Jinja2
-deepdiff
+deepdiff<6.4.0  # 6.4.0 version contains a bug https://github.com/seperman/deepdiff/issues/415


### PR DESCRIPTION
DeepDiff 6.4.0 version contains a bug https://github.com/seperman/deepdiff/issues/415 which breaks our CI