### PR TITLE
Add stagging/ to .codespellrc

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = venv*
+skip = staging,venv*
 ignore-words-list = sav


### PR DESCRIPTION
To avoid failure of `make lint` executed after `make test-integration`.