### PR TITLE
Restore retry, when the node have a table based on table function.

### DIFF
--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -452,6 +452,9 @@ class ClickhouseCTL:
     ) -> Sequence[Table]:
         """
         Get database tables.
+
+        A short query does not access the source of table if it was built from an external source.
+        Example: CREATE ... AS postgresql() or CREATE ... AS s3().
         """
         base_query_sql = GET_TABLES_SHORT_SQL if short_query else GET_TABLES_SQL
         query_sql = base_query_sql.format(
@@ -748,7 +751,7 @@ class ClickhouseCTL:
             engine=record.get("engine", None),
             disks=list(self._disks.values()),
             data_paths=record.get("data_paths", None)
-            if ("engine" in record) and (record["engine"].find("MergeTree") != -1)
+            if "MergeTree" in record.get("engine", "")
             else [],
             metadata_path=record.get("metadata_path", None),
             create_statement=record["create_table_query"],

--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -60,7 +60,7 @@ GET_TABLES_SHORT_SQL = strip_query(
     SELECT
         database,
         name,
-        create_table_query,
+        create_table_query
     FROM system.tables
     WHERE (empty('{db_name}') OR database = '{db_name}')
       AND (empty({table_names}) OR has(cast({table_names}, 'Array(String)'), name))

--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -445,12 +445,15 @@ class ClickhouseCTL:
         return self._ch_client.query(query_sql)
 
     def get_tables(
-        self, db_name: str = None, tables: Optional[Sequence[str]] = None, short_query : bool = False
+        self,
+        db_name: str = None,
+        tables: Optional[Sequence[str]] = None,
+        short_query: bool = False,
     ) -> Sequence[Table]:
         """
         Get database tables.
         """
-        base_query_sql = GET_TABLES_SHORT_SQL if short_query else GET_TABLES_SQL 
+        base_query_sql = GET_TABLES_SHORT_SQL if short_query else GET_TABLES_SQL
         query_sql = base_query_sql.format(
             db_name=escape(db_name) if db_name is not None else "",
             table_names=list(map(escape, tables)) if tables is not None else [],
@@ -742,12 +745,12 @@ class ClickhouseCTL:
         return Table(
             database=record["database"],
             name=record["name"],
-            engine=record.get("engine",None),
+            engine=record.get("engine", None),
             disks=list(self._disks.values()),
-            data_paths=record.get("data_paths",None)
-            if  ("engine" in record) and (record["engine"].find("MergeTree") != -1)
+            data_paths=record.get("data_paths", None)
+            if ("engine" in record) and (record["engine"].find("MergeTree") != -1)
             else [],
-            metadata_path=record.get("metadata_path",None),
+            metadata_path=record.get("metadata_path", None),
             create_statement=record["create_table_query"],
             uuid=record.get("uuid", None),
         )

--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -458,7 +458,7 @@ class TableBackup(BackupManager):
 
         # Filter out already restored tables.
         existing_tables = {}
-        for table in context.ch_ctl.get_tables():
+        for table in context.ch_ctl.get_tables(short_query=True):
             existing_tables[(table.database, table.name)] = table
 
         result: List[Table] = []

--- a/tests/integration/features/backup_restore.feature
+++ b/tests/integration/features/backup_restore.feature
@@ -211,7 +211,8 @@ Feature: Backup & Restore
       bucket: cloud-storage-01
       path: /data.tsv
     """
-    # Imitate the retry logic, when the first restore cmd is not finished correctly.
+    # If we restore the data, the table s3_test_table will be created through StorageProxy
+    # and not all the rows from system.table will be accessible. Check that we can perform the restore operation after restore.
     And we restore clickhouse backup #0 to clickhouse01
     And we restore clickhouse backup #0 to clickhouse01
     And we execute query on clickhouse01

--- a/tests/integration/features/backup_restore.feature
+++ b/tests/integration/features/backup_restore.feature
@@ -185,3 +185,35 @@ Feature: Backup & Restore
     """
     And we restore clickhouse backup #0 to clickhouse02
     Then clickhouse02 has same schema as clickhouse01
+
+  Scenario: Perform retry restore when exist the table based on the table function.
+    Given we execute query on clickhouse01
+    """
+    CREATE DATABASE test_db
+    """
+    When we put object in S3
+    """
+      bucket: cloud-storage-01
+      path: /data.tsv
+      data: '1'
+
+    """
+    When we execute query on clickhouse01
+    """
+    CREATE TABLE test_db.s3_test_table (v Int) AS
+    s3('{{conf['s3']['endpoint']}}/cloud-storage-01/data.tsv', '{{conf['s3']['access_key_id']}}', '{{conf['s3']['access_secret_key']}}', 'TSV');
+    """
+    And we create clickhouse01 clickhouse backup
+
+    Then we got the following backups on clickhouse01
+      | num | state    | data_count | link_count   |
+      | 0   | created  | 0          | 0            |
+
+    When we delete object in S3
+    """
+      bucket: cloud-storage-01
+      path: /data.tsv
+    """
+    # Imitate the retry logic, when the first restore cmd is not finished correctly.
+    When we restore clickhouse backup #0 to clickhouse01
+    When we restore clickhouse backup #0 to clickhouse01

--- a/tests/integration/steps/s3.py
+++ b/tests/integration/steps/s3.py
@@ -2,10 +2,11 @@
 Steps for interacting with S3.
 """
 
-from behave import given, then
+from behave import given, then, when
 from hamcrest import assert_that, equal_to
 from tests.integration.modules import s3
 from tests.integration.modules.minio import configure_s3_credentials, create_s3_buckets
+from tests.integration.modules.steps import get_step_data
 
 
 @given("a working s3")
@@ -38,3 +39,19 @@ def step_cloud_storage_bucket_contains_files(context, bucket, count):
         equal_to(count),
         f"Objects count = {len(objects)}, expected {count}, objects {objects}",
     )
+
+
+@when("we put object in S3")
+def step_create_file_in_s3(context):
+    conf = get_step_data(context)
+    s3_client = s3.S3Client(context, conf["bucket"])
+    s3_client.upload_data(conf["data"], conf["path"])
+    assert s3_client.path_exists(conf["path"])
+
+
+@when("we delete object in S3")
+def stop_delete_file_in_S3(context):
+    conf = get_step_data(context)
+    s3_client = s3.S3Client(context, conf["bucket"])
+    s3_client.delete_data(conf["path"])
+    assert not s3_client.path_exists(conf["path"])


### PR DESCRIPTION

We got a table based on table function. Example:
```
CREATE table test_pg (id Int, value Int) AS postgresql('localhost:5432', 'test_db', 'test_table', 'test1', '123456')
```
Instead of `posgresql` we can have  [another one](https://clickhouse.com/docs/en/sql-reference/table-functions) which should take data from the remote source, like  `s3` or `redis`.

Scenario:
1. Create backup.
2. Trying to restore to the cluster where data source for the table function is unreachable. 
3. Trying to run a restore again.
Result:
```
      
      Traceback (most recent call last):
        File "/usr/local/bin/ch-backup", line 33, in <module>
          sys.exit(load_entry_point('ch-backup', 'console_scripts', 'ch-backup')())
        File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
          return self.main(*args, **kwargs)
        File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1078, in main
          rv = self.invoke(ctx)
        File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
          return _process_result(sub_ctx.command.invoke(sub_ctx))
        File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
          return ctx.invoke(self.callback, **ctx.params)
        File "/usr/local/lib/python3.10/site-packages/click/core.py", line 783, in invoke
          return __callback(*args, **kwargs)
        File "/usr/local/lib/python3.10/site-packages/click/decorators.py", line 33, in new_func
          return f(get_current_context(), *args, **kwargs)
        File "/var/tmp/ch-backup/ch_backup/cli.py", line 161, in wrapper
          result = ctx.invoke(f, ctx, ctx.obj["backup"], *args, **kwargs)
        File "/usr/local/lib/python3.10/site-packages/click/core.py", line 783, in invoke
          return __callback(*args, **kwargs)
        File "/var/tmp/ch-backup/ch_backup/cli.py", line 687, in restore_command
          ch_backup.restore(
        File "/var/tmp/ch-backup/ch_backup/ch_backup.py", line 287, in restore
          self._restore(
        File "/var/tmp/ch-backup/ch_backup/ch_backup.py", line 506, in _restore
          self._table_backup_manager.restore(
        File "/var/tmp/ch-backup/ch_backup/logic/table.py", line 231, in restore
          tables_to_restore = self._preprocess_tables_to_restore(
        File "/var/tmp/ch-backup/ch_backup/logic/table.py", line 461, in _preprocess_tables_to_restore
          for table in context.ch_ctl.get_tables():
        File "/var/tmp/ch-backup/ch_backup/clickhouse/control.py", line 444, in get_tables
          for row in self._ch_client.query(query_sql)["data"]:
        File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 289, in wrapped_f
          return self(f, *args, **kw)
        File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 379, in __call__
          do = self.iter(retry_state=retry_state)
        File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 314, in iter
          return fut.result()
        File "/usr/local/lib/python3.10/concurrent/futures/_base.py", line 451, in result
          return self.__get_result()
        File "/usr/local/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
          raise self._exception
        File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 382, in __call__
          result = fn(*args, **kwargs)
        File "/var/tmp/ch-backup/ch_backup/clickhouse/client.py", line 66, in query
          raise ClickhouseError(e.response.text.strip()) from e
      ch_backup.clickhouse.client.ClickhouseError: Code: 499. DB::Exception: The specified key does not exist.: while reading key: data.tsv, from bucket: cloud-storage-01: Cannot extract table structure from TSV format file. You can specify the structure manually: (in file/uri cloud-storage-01/data.tsv): While executing Tables. (S3_ERROR) (version 23.8.2.7 (official build))
```
To perform restore operation `ch-backup` tool executing select from `system.tables`, where  some of the data is inaccessible.  


Ps.
I found another problem related with table functions for tables:
1. Create table with unreachable source: `CREATE table test_pg (id Int, value Int) AS postgresql('unreaceble-source:5432', 'test_db', 'test_table', 'test1', '123456')`
2. Perform the `backup`.

