### PR TITLE
Fix pylint dependency

### DIFF
--- a/ch_backup/config.py
+++ b/ch_backup/config.py
@@ -92,7 +92,7 @@ DEFAULT_CONFIG = {
         # chunk_size will be multiplied on a required number of times
         # to satisfy the limit.
         "max_chunk_count": 10000,
-        # Enable bulk detete (DeleteObjects in S3 API)
+        # Enable bulk delete (DeleteObjects in S3 API)
         "bulk_delete_enabled": True,
         # How many files we can delete by bulk delete operation in one call
         "bulk_delete_chunk_size": 1000,

--- a/ch_backup/util.py
+++ b/ch_backup/util.py
@@ -237,7 +237,7 @@ def get_table_zookeeper_paths(tables: Iterable) -> Iterable[Tuple]:
         )
         if not match:
             raise ClickhouseBackupError(
-                f"Couldn`t parse create statement for zk path: {table}"
+                f"Couldn't parse create statement for zk path: {table}"
             )
         result.append((table, match.group("zk_path")))
     return result

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 isort;              python_version >="3.8"
 black;              python_version >="3.8"
 ruff;               python_version >="3.8"
-pylint;             python_version >="3.8"
+pylint<3.0;         python_version >="3.8"
 mypy==1.5.1;        python_version >="3.8"
 mypy-boto3-s3;      python_version >="3.8"
 types-PyYAML;       python_version >="3.8"


### PR DESCRIPTION
When apply `pylint-3.0.1` got a lot errors like:

```
ch_backup/zookeeper/zookeeper.py:1:0: R0401: Cyclic import (ch_backup.logging -> ch_backup.util) (cyclic-import)
ch_backup/zookeeper/zookeeper.py:1:0: R0801: Similar lines in 2 files
==ch_backup.storage.async_pipeline.stages.filesystem.write_files_stage:[102:143]
==ch_backup.storage.stages.filesystem:[186:226]
        buf = self._tarstream.read(self._bytes_to_process)
        self._name_from_buffer += buf
        self._bytes_to_process -= len(buf)

        if self._bytes_to_process > 0:
            return False

        self._state = State.SKIP_BYTES
        if self._tarinfo.size % BLOCKSIZE > 0:
            self._bytes_to_process = BLOCKSIZE - (self._tarinfo.size % BLOCKSIZE)

        return True

    def _process_data(self) -> bool:
        assert self._tarinfo
        assert self._fobj

        buf = self._tarstream.read(self._bytes_to_process)
        self._fobj.write(buf)
        self._bytes_to_process -= len(buf)

        if self._bytes_to_process > 0:
            return False

        self._state = State.SKIP_BYTES
        if self._tarinfo.size % BLOCKSIZE > 0:
            self._bytes_to_process = BLOCKSIZE - (self._tarinfo.size % BLOCKSIZE)

        return True

    def _skip_bytes(self) -> bool:
        buf = self._tarstream.read(self._bytes_to_process)
        assert buf.count(NUL) == len(buf), buf
        self._bytes_to_process -= len(buf)
        if self._bytes_to_process > 0:
            return False

        self._state = State.READ_HEADER
        return True
```

With `pylint-2.17.7` everything fine. Example: [CI](https://pipelinesghubeus13.actions.githubusercontent.com/iV7AG4tapbYiJudWNlPWiAUeKEl1aymTidATcIwTd7BaE8KkKt/_apis/pipelines/1/runs/675/signedlogcontent/2?urlExpires=2023-10-10T07%3A47%3A18.7183767Z&urlSigningMethod=HMACV1&urlSignature=gL69SFYKyuhTZOIxcxUfcRoKTQuNdFOD72dCqERRWvY%3D)

Also fixed  error after update to `codespell-2.2.6`.