### PR TITLE
Upload backup metadata during backup

### DIFF
--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -4,7 +4,7 @@ Management of backup data layout.
 
 import os
 from pathlib import Path
-from typing import List, Optional, Sequence
+from typing import Callable, List, Optional, Sequence
 from urllib.parse import quote
 
 from ch_backup import logging
@@ -151,7 +151,9 @@ class BackupLayout:
             msg = f'Failed to upload udf metadata "{remote_path}"'
             raise StorageError(msg) from e
 
-    def upload_data_part(self, backup_name: str, fpart: FrozenPart) -> None:
+    def upload_data_part(
+        self, backup_name: str, fpart: FrozenPart, callback: Callable
+    ) -> None:
         """
         Upload part data.
         """
@@ -174,6 +176,7 @@ class BackupLayout:
                 is_async=True,
                 encryption=True,
                 delete=True,
+                callback=callback,
             )
         except Exception as e:
             msg = f"Failed to create async upload of {remote_path}"

--- a/ch_backup/config.py
+++ b/ch_backup/config.py
@@ -64,6 +64,7 @@ DEFAULT_CONFIG = {
         "restore_context_path": "/tmp/ch_backup_restore_state.json",  # nosec
         "validate_part_after_upload": False,
         "restore_fail_on_attach_error": False,
+        "update_metadata_interval": _as_seconds("30 min"),
     },
     "storage": {
         "type": "s3",

--- a/ch_backup/logic/upload_part_observer.py
+++ b/ch_backup/logic/upload_part_observer.py
@@ -2,12 +2,8 @@
 import time
 from typing import List, Optional
 
-from humanfriendly import parse_timespan
-
 from ch_backup.backup.metadata.part_metadata import PartMetadata
 from ch_backup.backup_context import BackupContext
-
-DEFAULT_INTERVAL = parse_timespan("30 min")
 
 
 class UploadPartObserver:
@@ -22,9 +18,7 @@ class UploadPartObserver:
         self._context = context
         self._last_time = time.time()
         self._uploaded_parts: List[PartMetadata] = []
-        self._interval = self._context.config.get(
-            "update_metadata_interval", DEFAULT_INTERVAL
-        )
+        self._interval = self._context.config["update_metadata_interval"]
 
     def __call__(
         self, part: PartMetadata, exception: Optional[Exception] = None

--- a/ch_backup/logic/upload_part_observer.py
+++ b/ch_backup/logic/upload_part_observer.py
@@ -1,0 +1,44 @@
+"""Uploading part observer."""
+import time
+from typing import List, Optional
+
+from ch_backup.backup.metadata.part_metadata import PartMetadata
+from ch_backup.backup_context import BackupContext
+
+
+class UploadPartObserver:
+    """
+    Observe uploading parts.
+
+    Update backup metadata with specified interval after completion of
+    uploading every part to object storage.
+    """
+
+    def __init__(self, context: BackupContext) -> None:
+        self._context = context
+        self._last_time = time.time()
+        self._uploaded_parts: List[PartMetadata] = []
+        self._interval = self._context.config["update_metadata_interval"]
+
+    def __call__(
+        self, part: PartMetadata, exception: Optional[Exception] = None
+    ) -> None:
+        if exception:
+            return
+
+        self._uploaded_parts.append(part)
+        self._context.backup_meta.add_part(part)
+
+        now = time.time()
+        if now - self._last_time >= self._interval:
+            self._context.backup_layout.upload_backup_metadata(
+                self._context.backup_meta
+            )
+            self._last_time = now
+
+    @property
+    def uploaded_parts(self) -> List[PartMetadata]:
+        """
+        Return uploaded parts metadata.
+        """
+        return self._uploaded_parts

--- a/ch_backup/logic/upload_part_observer.py
+++ b/ch_backup/logic/upload_part_observer.py
@@ -1,6 +1,6 @@
 """Uploading part observer."""
 import time
-from typing import List, Optional
+from typing import List
 
 from ch_backup.backup.metadata.part_metadata import PartMetadata
 from ch_backup.backup_context import BackupContext
@@ -20,12 +20,7 @@ class UploadPartObserver:
         self._uploaded_parts: List[PartMetadata] = []
         self._interval = self._context.config["update_metadata_interval"]
 
-    def __call__(
-        self, part: PartMetadata, exception: Optional[Exception] = None
-    ) -> None:
-        if exception:
-            return
-
+    def __call__(self, part: PartMetadata) -> None:
         self._uploaded_parts.append(part)
         self._context.backup_meta.add_part(part)
 

--- a/ch_backup/logic/upload_part_observer.py
+++ b/ch_backup/logic/upload_part_observer.py
@@ -2,8 +2,12 @@
 import time
 from typing import List, Optional
 
+from humanfriendly import parse_timespan
+
 from ch_backup.backup.metadata.part_metadata import PartMetadata
 from ch_backup.backup_context import BackupContext
+
+DEFAULT_INTERVAL = parse_timespan("30 min")
 
 
 class UploadPartObserver:
@@ -18,7 +22,9 @@ class UploadPartObserver:
         self._context = context
         self._last_time = time.time()
         self._uploaded_parts: List[PartMetadata] = []
-        self._interval = self._context.config["update_metadata_interval"]
+        self._interval = self._context.config.get(
+            "update_metadata_interval", DEFAULT_INTERVAL
+        )
 
     def __call__(
         self, part: PartMetadata, exception: Optional[Exception] = None

--- a/ch_backup/storage/async_pipeline/base_pipeline/exec_pool.py
+++ b/ch_backup/storage/async_pipeline/base_pipeline/exec_pool.py
@@ -67,9 +67,7 @@ class ExecPool:
 
             try:
                 future.result()
-            except Exception as ex:
-                if job.callback:
-                    job.callback(ex)
+            except Exception:
                 if keep_going:
                     logging.warning(
                         'Job "{}" generated an exception, skipping due to keep_going flag',

--- a/ch_backup/storage/async_pipeline/base_pipeline/exec_pool.py
+++ b/ch_backup/storage/async_pipeline/base_pipeline/exec_pool.py
@@ -1,10 +1,23 @@
 """
 Class for executing callables on specified pool.
 """
-from concurrent.futures import ALL_COMPLETED, Executor, Future, wait
-from typing import Any, Callable, Dict
+from concurrent.futures import Executor, Future, as_completed
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
 
 from ch_backup import logging
+
+
+@dataclass
+class Job:
+    """
+    Job submitted to ExecPool.
+
+    Callback is executed after job completion.
+    """
+
+    id_: str
+    callback: Optional[Callable]
 
 
 class ExecPool:
@@ -15,7 +28,7 @@ class ExecPool:
     """
 
     def __init__(self, executor: Executor) -> None:
-        self._futures: Dict[str, Future] = {}
+        self._future_to_job: Dict[Future, Job] = {}
         self._pool = executor
 
     def shutdown(self, graceful: bool = True) -> None:
@@ -24,15 +37,22 @@ class ExecPool:
         """
         self._pool.shutdown(wait=graceful)
 
-    def submit(self, future_id: str, func: Callable, *args: Any, **kwargs: Any) -> None:
+    def submit(
+        self,
+        job_id: str,
+        func: Callable,
+        callback: Optional[Callable],
+        *args: Any,
+        **kwargs: Any
+    ) -> None:
         """
         Schedule job for execution
         """
-        if future_id in self._futures:
+        if job_id in [job.id_ for job in self._future_to_job.values()]:
             raise RuntimeError("Duplicate")
+
         future = self._pool.submit(func, *args, **kwargs)
-        future.add_done_callback(lambda _: logging.debug("Future {} completed", future_id))  # type: ignore[misc]
-        self._futures[future_id] = future
+        self._future_to_job[future] = Job(job_id, callback)
 
     def wait_all(self, keep_going: bool = False) -> None:
         """
@@ -41,24 +61,31 @@ class ExecPool:
         Args:
             keep_going - skip exceptions raised by futures instead of propagating it.
         """
-        wait(self._futures.values(), return_when=ALL_COMPLETED)
+        for future in as_completed(self._future_to_job):
+            job = self._future_to_job[future]
+            logging.debug("Future {} completed", job.id_)
 
-        for future_id, future in self._futures.items():
             try:
                 future.result()
-            except Exception:
+            except Exception as ex:
+                if job.callback:
+                    job.callback(ex)
                 if keep_going:
                     logging.warning(
-                        'Future "{}" generated an exception, skipping due to keep_going flag',
-                        future_id,
+                        'Job "{}" generated an exception, skipping due to keep_going flag',
+                        job.id_,
                         exc_info=True,
                     )
                     continue
                 logging.error(
-                    'Future "{}" generated an exception:', future_id, exc_info=True
+                    'Job "{}" generated an exception:', job.id_, exc_info=True
                 )
                 raise
-        self._futures = {}
+
+            if job.callback:
+                job.callback()
+
+        self._future_to_job = {}
 
     def __del__(self) -> None:
         """

--- a/ch_backup/storage/async_pipeline/pipeline_executor.py
+++ b/ch_backup/storage/async_pipeline/pipeline_executor.py
@@ -85,6 +85,7 @@ class PipelineExecutor:
         is_async: bool,
         encryption: bool,
         delete: bool,
+        callback: Optional[Callable] = None,
     ) -> None:
         """
         Archive to tarball and upload files from local filesystem.
@@ -101,7 +102,7 @@ class PipelineExecutor:
             encryption,
             delete_after=delete,
         )
-        self._exec_pipeline(job_id, pipeline, is_async)
+        self._exec_pipeline(job_id, pipeline, is_async, callback)
 
     def download_data(
         self, remote_path: str, is_async: bool, encryption: bool
@@ -169,15 +170,30 @@ class PipelineExecutor:
         if self._exec_pool:
             self._exec_pool.wait_all(keep_going)
 
-    def _exec_pipeline(self, job_id: str, pipeline: Callable, is_async: bool) -> Any:
+    def _exec_pipeline(
+        self,
+        job_id: str,
+        pipeline: Callable,
+        is_async: bool,
+        callback: Optional[Callable] = None,
+    ) -> Any:
         """
         Run pipeline inplace or schedule for exec in process pool
         """
 
         if is_async and self._exec_pool:
-            return self._exec_pool.submit(job_id, pipeline)
+            return self._exec_pool.submit(job_id, pipeline, callback)
 
-        return pipeline()
+        try:
+            result = pipeline()
+        except Exception as ex:
+            if callback:
+                callback(ex)
+            raise
+
+        if callback:
+            callback()
+        return result
 
     @staticmethod
     def _make_job_id(job_name: str, *args: Any) -> str:

--- a/ch_backup/storage/async_pipeline/pipeline_executor.py
+++ b/ch_backup/storage/async_pipeline/pipeline_executor.py
@@ -184,13 +184,7 @@ class PipelineExecutor:
         if is_async and self._exec_pool:
             return self._exec_pool.submit(job_id, pipeline, callback)
 
-        try:
-            result = pipeline()
-        except Exception as ex:
-            if callback:
-                callback(ex)
-            raise
-
+        result = pipeline()
         if callback:
             callback()
         return result

--- a/ch_backup/storage/loader.py
+++ b/ch_backup/storage/loader.py
@@ -2,7 +2,7 @@
 Module providing API for storage management (upload and download data, check
 remote path on existence, etc.).
 """
-from typing import List, Sequence
+from typing import Callable, List, Optional, Sequence
 
 from ch_backup.storage.async_pipeline.pipeline_executor import PipelineExecutor
 from ch_backup.storage.engine import get_storage_engine
@@ -76,6 +76,7 @@ class StorageLoader:
         is_async: bool = False,
         encryption: bool = False,
         delete: bool = False,
+        callback: Optional[Callable] = None,
     ) -> str:
         """
         Upload multiple files as tarball.
@@ -89,6 +90,7 @@ class StorageLoader:
             is_async=is_async,
             encryption=encryption,
             delete=delete,
+            callback=callback,
         )
         return remote_path
 

--- a/tests/unit/test_backup_tables.py
+++ b/tests/unit/test_backup_tables.py
@@ -7,6 +7,7 @@ from ch_backup.backup.deduplication import DedupInfo
 from ch_backup.backup.metadata.backup_metadata import BackupMetadata
 from ch_backup.backup_context import BackupContext
 from ch_backup.clickhouse.models import Database, Table
+from ch_backup.config import DEFAULT_CONFIG
 from ch_backup.logic.table import TableBackup
 
 UUID = "fa8ff291-1922-4b7f-afa7-06633d5e16ae"
@@ -26,8 +27,7 @@ def test_backup_table_skipping_if_metadata_updated_during_backup(
     )
 
     # Prepare involved data objects
-    config = {"backup": {"validate_part_after_upload": False}}
-    context = BackupContext(config)  # type: ignore[arg-type]
+    context = BackupContext(DEFAULT_CONFIG)  # type: ignore[arg-type]
     db = Database(db_name, "MergeTree", "/var/lib/clickhouse/metadata/db1.sql")
     dedup_info = DedupInfo()
     table_backup = TableBackup()

--- a/tests/unit/test_upload_part_observer.py
+++ b/tests/unit/test_upload_part_observer.py
@@ -1,0 +1,117 @@
+import copy
+from typing import List
+from unittest.mock import Mock, patch
+
+from tests.unit.utils import parametrize
+
+from ch_backup.backup.metadata.backup_metadata import BackupMetadata
+from ch_backup.backup.metadata.part_metadata import PartMetadata
+from ch_backup.backup.metadata.table_metadata import TableMetadata
+from ch_backup.backup_context import BackupContext
+from ch_backup.clickhouse.models import Database
+from ch_backup.logic.upload_part_observer import UploadPartObserver
+
+UUID = "fa8ff291-1922-4b7f-afa7-06633d5e16ae"
+DB_NAME = "test_db"
+TABLE_NAME = "test_table"
+ENGINE = "MergeTree"
+BACKUP_NAME = "TestBackup"
+BACKUP_META = BackupMetadata(
+    name=BACKUP_NAME,
+    path=f"ch_backup/{BACKUP_NAME}",
+    version="1.0.100",
+    ch_version="19.1.16",
+    time_format="%Y-%m-%dT%H:%M:%S%Z",
+    hostname="clickhouse01.test_net_711",
+)
+DB = Database(DB_NAME, ENGINE, f"/var/lib/clickhouse/metadata/{DB_NAME}.sql")
+
+
+@parametrize(
+    {
+        "id": "One part before interval",
+        "args": {
+            "times": [0, 1],
+            "part_names": ["1"],
+            "interval": 2,
+            "expected_upload_metadata": 0,
+        },
+    },
+    {
+        "id": "One part after interval",
+        "args": {
+            "times": [0, 2],
+            "part_names": ["1"],
+            "interval": 1,
+            "expected_upload_metadata": 1,
+        },
+    },
+    {
+        "id": "One before. One after",
+        "args": {
+            "times": [0, 1, 10],
+            "part_names": ["1", "2"],
+            "interval": 5,
+            "expected_upload_metadata": 1,
+        },
+    },
+    {
+        "id": "Two parts after interval",
+        "args": {
+            "times": [0, 1, 10],
+            "part_names": ["1", "2"],
+            "interval": 1,
+            "expected_upload_metadata": 2,
+        },
+    },
+    {
+        "id": "Mix",
+        "args": {
+            "times": [0, 1, 2, 10, 20],
+            "part_names": ["1", "2", "3", "4"],
+            "interval": 5,
+            "expected_upload_metadata": 2,
+        },
+    },
+)
+def test_observer(
+    times: List[int],
+    part_names: List[str],
+    interval: int,
+    expected_upload_metadata: int,
+) -> None:
+    config = {"backup": {"update_metadata_interval": interval}}
+
+    backup_meta = copy.deepcopy(BACKUP_META)
+    backup_meta.add_database(DB)
+
+    context = BackupContext(config)  # type: ignore[arg-type]
+    context.backup_meta = backup_meta
+
+    # Add table metadata to backup metadata
+    context.backup_meta.add_table(TableMetadata(DB_NAME, TABLE_NAME, ENGINE, UUID))
+
+    context.backup_layout = Mock()
+
+    with patch("time.time", side_effect=times):
+        observer = UploadPartObserver(context)
+
+        for name in part_names:
+            part = PartMetadata(
+                DB_NAME,
+                TABLE_NAME,
+                name,
+                "AABBCCDD",
+                1000,
+                ["column1.idx"],
+                True,
+                None,
+                None,
+            )
+            observer(part)
+
+    assert (
+        context.backup_layout.upload_backup_metadata.call_count
+        == expected_upload_metadata
+    )
+    assert len(context.backup_meta.get_parts()) == len(part_names)


### PR DESCRIPTION
Upload backup metadata with uploaded parts periodically during backup process. Interval of updating is set under `backup` config key `update_metadata_interval`. Default: 30 min.

Problem being solved:
`ch-backup` updates backup metadata in S3 storage after all parts for a table has been uploaded. If creation of backup is stopped unexpectedly (e.g. SIGKILL) all uploaded parts for a table can't be used for deduplication by next backups, because metadata about them was not uploaded.

