### PR TITLE
Improving logging for lock manager

### DIFF
--- a/ch_backup/ch_backup.py
+++ b/ch_backup/ch_backup.py
@@ -1,7 +1,6 @@
 """
 Clickhouse backup logic
 """
-import platform
 from collections import defaultdict
 from copy import copy
 from datetime import timedelta
@@ -18,7 +17,6 @@ from ch_backup.backup.metadata import BackupMetadata, BackupState, TableMetadata
 from ch_backup.backup.restore_context import RestoreContext
 from ch_backup.backup.sources import BackupSources
 from ch_backup.backup_context import BackupContext
-from ch_backup.clickhouse.client import ClickhouseError
 from ch_backup.clickhouse.config import ClickhouseConfig
 from ch_backup.clickhouse.control import ClickhouseCTL
 from ch_backup.clickhouse.models import Database
@@ -106,22 +104,6 @@ class ClickhouseBackup:
 
         return backups
 
-    def _lock_id(self, operation: str) -> Optional[str]:
-        lock_id = operation
-        # if the replica name part of the id starts with '$' it means
-        # we used `platform.node()`
-        missing_shard = "/UNKNOWN"
-        missing_replica = f"/${platform.node()}"
-        lock_id = operation
-        try:
-            shard, replica = self._context.ch_ctl.get_shard_and_replica_name()
-            lock_id += f"/{shard}" if shard else missing_shard
-            lock_id += f"/{replica}" if replica else missing_replica
-        except ClickhouseError:
-            logging.error("Error in forming lock_id.", exc_info=True)
-            lock_id = f"{lock_id}{missing_shard}{missing_replica}"
-        return lock_id
-
     def backup(
         self,
         sources: BackupSources,
@@ -180,7 +162,7 @@ class ClickhouseBackup:
 
         skip_lock = self._check_schema_only_backup_skip_lock(sources)
 
-        with self._context.locker(disabled=skip_lock, lock_id=self._lock_id("BACKUP")):
+        with self._context.locker(disabled=skip_lock, operation="BACKUP"):
             self._context.backup_layout.upload_backup_metadata(
                 self._context.backup_meta
             )
@@ -306,7 +288,7 @@ class ClickhouseBackup:
         logging.info("All required databases are present in backup.")
 
         with self._context.locker(
-            distributed=not sources.schema_only, lock_id=self._lock_id("RESTORE")
+            distributed=not sources.schema_only, operation="RESTORE"
         ):
             self._restore(
                 sources=sources,
@@ -331,7 +313,7 @@ class ClickhouseBackup:
         found = False
         deleting_backups = []
         retained_backups = []
-        with self._context.locker(lock_id=self._lock_id("DELETE")):
+        with self._context.locker(operation="DELETE"):
             # Use light metadata in backups iteration to avoid high memory usage.
             for i, backup in enumerate(
                 self._context.backup_layout.get_backups(use_light_meta=True)
@@ -384,7 +366,7 @@ class ClickhouseBackup:
         deleting_backups: List[BackupMetadata] = []
         backup_names = self._context.backup_layout.get_backup_names()
 
-        with self._context.locker(lock_id=self._lock_id("PURGE")):
+        with self._context.locker(operation="PURGE"):
             # Use light metadata in backups iteration to avoid high memory usage.
             for backup in self._context.backup_layout.get_backups(use_light_meta=True):
                 if backup.name not in backup_names:

--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager, suppress
 from hashlib import md5
 from pathlib import Path
 from tarfile import BLOCKSIZE  # type: ignore
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from pkg_resources import parse_version
 
@@ -280,17 +280,6 @@ GET_ZOOKEEPER_ADMIN_UUID = strip_query(
         value
     FROM system.zookeeper
     WHERE (path = '/clickhouse/access/uuid') AND (value LIKE 'ATTACH USER admin%')
-    FORMAT JSON
-"""
-)
-
-GET_SHARD_AND_REPLICA_NAME = strip_query(
-    """
-    SELECT
-        last_value_respect_nullsArray(splitByString('/', zookeeper_path)) AS shard_name,
-        last_value_respect_nullsArray(splitByString('/', replica_path)) AS replica_name
-    FROM system.replicas
-    LIMIT 1
     FORMAT JSON
 """
 )
@@ -826,16 +815,6 @@ class ClickhouseCTL:
         Reload ClickHouse configuration query.
         """
         self._ch_client.query(RELOAD_CONFIG_SQL, timeout=self._timeout)
-
-    def get_shard_and_replica_name(self) -> Tuple[str, str]:
-        """
-        Gets the current shard and replica names
-        """
-        result = self._ch_client.query(
-            GET_SHARD_AND_REPLICA_NAME, timeout=self._timeout
-        )
-        result = result.get("data", [{}])[0]
-        return result.get("shard_name"), result.get("replica_name")
 
     @staticmethod
     @contextmanager


### PR DESCRIPTION
Improving logging for lock manager by adding information about shard and replica name on lock acquisition. This would make possible to list the lock contenders on LockTimeout errors, thus helping the investigation of relative issues