### PR TITLE
Add cli parameters to override config value or config section

### DIFF
--- a/ch_backup/cli.py
+++ b/ch_backup/cli.py
@@ -3,17 +3,15 @@
 Command-line interface.
 """
 import json
-import re
 import signal
 import sys
 import typing
 import uuid
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 from functools import wraps
-from typing import Union
+from typing import Iterable, Tuple, Union
 
-from click import Choice, ParamType, Path, argument, pass_context, style
-from click.types import StringParamType
+from click import Choice, Path, argument, pass_context, style
 from cloup import (
     Color,
     Context,
@@ -25,7 +23,7 @@ from cloup import (
     option_group,
 )
 from cloup.constraints import constraint, mutually_exclusive
-from humanfriendly import InvalidTimespan, format_timespan, parse_timespan
+from humanfriendly import format_timespan
 from tabulate import tabulate
 
 from ch_backup.exceptions import TerminatingSignal
@@ -35,6 +33,7 @@ from .backup.metadata import BackupState, TableMetadata
 from .backup.sources import BackupSources
 from .ch_backup import ClickhouseBackup
 from .config import DEFAULT_CONFIG, Config
+from .params import JsonParamType, KeyValues, KeyValuesList, List, String, TimeSpan
 from .util import drop_privileges, setup_environment, utcnow
 from .version import get_version
 
@@ -100,6 +99,17 @@ signal.signal(signal.SIGINT, signal_handler)
     help="Disable certificate verification for https protocol.",
 )
 @option("--zk-hosts", type=str, help="Use specified zk hosts for connection to the ZK")
+@option(
+    "--config-parameter",
+    "config_parameters",
+    multiple=True,
+    type=(str, JsonParamType()),
+    metavar="PATH VALUE",
+    help="Paths and values to override ch-backup config values. "
+    'Path should contains a string with dot separated keys (e.g. "backup.min_interval.minutes"). '
+    "Value should be json-serializable string or plain value (string, true/false, number). "
+    "Can be specified multiple times to override several settings.",
+)
 @pass_context
 def cli(
     ctx: Context,
@@ -110,6 +120,7 @@ def cli(
     ca_path: Union[str, bool],
     insecure: bool,
     zk_hosts: str,
+    config_parameters: Iterable[Tuple[str, dict]],
 ) -> None:
     """Tool for managing ClickHouse backups."""
     if insecure:
@@ -126,6 +137,10 @@ def cli(
         cfg["clickhouse"]["ca_path"] = ca_path
     if zk_hosts is not None:
         cfg["zookeeper"]["hosts"] = zk_hosts
+
+    if config_parameters is not None:
+        cli_cfg = _build_cli_cfg_from_config_parameters(config_parameters)
+        cfg.merge(cli_cfg)
 
     logging.configure(cfg["loguru"])
     setup_environment(cfg["main"])
@@ -168,152 +183,6 @@ def command(*args, **kwargs):
         return cli.command(*args, **kwargs)(wrapper)
 
     return decorator
-
-
-class List(ParamType):
-    """
-    List type for command-line parameters.
-    """
-
-    name = "list"
-
-    def __init__(self, separator=",", regexp=None):
-        self.separator = separator
-        self.regexp_str = regexp
-        self.regexp = re.compile(regexp) if regexp else None
-
-    def convert(self, value, param, ctx):
-        """
-        Convert input value into list of items.
-        """
-        try:
-            result = list(map(str.strip, value.split(self.separator)))
-
-            if self.regexp:
-                for item in result:
-                    if self.regexp.fullmatch(item) is None:
-                        raise ValueError()
-
-            return result
-
-        except ValueError:
-            msg = f'"{value}" is not a valid list of items'
-            if self.regexp:
-                msg += f" matching the format: {self.regexp_str}"
-
-            self.fail(msg, param, ctx)
-
-
-KeyValue = typing.Dict[str, str]
-
-
-class KeyValueList(List):
-    """
-    List of key-value type for command-line parameters.
-    """
-
-    name = "kvlist"
-
-    def __init__(self, kv_separator=":", list_separator=","):
-        super().__init__(separator=list_separator)
-        self.kv_separator = kv_separator
-
-    def convert(self, value, param, ctx):
-        """
-        Convert input value into list of key-value.
-        """
-        result: KeyValue = {}
-
-        try:
-            kvs = super().convert(value, param, ctx)
-
-            for kv in kvs:
-                k, v = list(map(str.strip, kv.split(self.kv_separator)))
-                result[k] = v
-
-            return result
-
-        except ValueError:
-            self.fail(f'"{value}" is not a valid list of key-value', param, ctx)
-
-
-KeyValues = typing.Dict[str, typing.List[str]]
-
-
-class KeyValuesList(KeyValueList):
-    """
-    List of key-values type for command-line parameters.
-    """
-
-    name = "kvslist"
-
-    def __init__(self, value_separator=",", kv_separator=":", list_separator=";"):
-        super().__init__(kv_separator=kv_separator, list_separator=list_separator)
-        self.value_separator = value_separator
-
-    def convert(self, value, param, ctx):
-        """
-        Convert input value into list of key-values.
-        """
-        result: KeyValues = defaultdict(list)
-
-        try:
-            kvs: KeyValue = super().convert(value, param, ctx)
-
-            for k in kvs.keys():
-                vs = list(map(str.strip, kvs[k].split(self.value_separator)))
-                result[k].extend(vs)
-
-            return dict(result)
-
-        except ValueError:
-            self.fail(f'"{value}" is not a valid list of key-values', param, ctx)
-
-
-class String(StringParamType):
-    """
-    String type for command-line parameters with support of macros and
-    regexp-based validation.
-    """
-
-    name = "string"
-
-    def __init__(self, regexp=None, macros=None):
-        self.regexp_str = regexp
-        self.regexp = re.compile(regexp) if regexp else None
-        self.macros = macros
-
-    def convert(self, value, param, ctx):
-        """
-        Parse input value.
-        """
-        if self.macros:
-            for macro, replacement in self.macros.items():
-                value = value.replace(macro, replacement)
-
-        if self.regexp:
-            if self.regexp.fullmatch(value) is None:
-                msg = f'"{value}" does not match the format: {self.regexp_str}'
-                self.fail(msg, param, ctx)
-
-        return super().convert(value, param, ctx)
-
-
-class TimeSpan(ParamType):
-    """
-    TimeSpan type for command-line parameters.
-    """
-
-    name = "TimeSpan"
-
-    def convert(self, value, param, ctx):
-        """
-        Convert timespan string into seconds.
-        """
-        try:
-            return int(parse_timespan(value))
-        except InvalidTimespan as e:
-            self.fail(f'"{value}" is not a valid timespan: {str(e)}', param, ctx)
 
 
 @command(name="list")
@@ -827,5 +696,42 @@ def _key_values_to_tables_metadata(
     for k, vs in kvs.items():
         for v in vs:
             result.append(TableMetadata(database=k, name=v, engine="", uuid=""))
+
+    return result
+
+
+def _build_cli_cfg_from_config_parameters(values: Iterable[Tuple[str, dict]]) -> dict:
+    """
+    Build config dict from specified keys and values in plain format.
+    Duplicate keys are ignored in favor of the last entry.
+    """
+
+    def _split_key(key: str) -> typing.List[str]:
+        return key.split(".")
+
+    values_by_uniq_key: dict[str, dict] = {}
+    for key, value in values:
+        values_by_uniq_key[key] = value
+
+    values_sorted = sorted(
+        values_by_uniq_key.items(), key=lambda x: len(_split_key(x[0]))
+    )
+
+    result: dict = {}
+    for key, value in values_sorted:
+        path = _split_key(key)
+        if not path:
+            continue
+
+        subresult = result
+        for i, subkey in enumerate(path):
+            if i != len(path) - 1 and not isinstance(subresult, dict):
+                continue
+
+            if i == len(path) - 1:
+                subresult[subkey] = value
+            elif subkey not in subresult:
+                subresult[subkey] = {}
+            subresult = subresult[subkey]
 
     return result

--- a/ch_backup/params.py
+++ b/ch_backup/params.py
@@ -1,0 +1,177 @@
+"""
+ParamType declarations.
+"""
+import json
+import re
+import typing
+from collections import defaultdict
+
+from click import ParamType
+from click.types import StringParamType
+from humanfriendly import InvalidTimespan, parse_timespan
+
+
+class List(ParamType):
+    """
+    List type for command-line parameters.
+    """
+
+    name = "list"
+
+    def __init__(self, separator=",", regexp=None):
+        self.separator = separator
+        self.regexp_str = regexp
+        self.regexp = re.compile(regexp) if regexp else None
+
+    def convert(self, value, param, ctx):
+        """
+        Convert input value into list of items.
+        """
+        try:
+            result = list(map(str.strip, value.split(self.separator)))
+
+            if self.regexp:
+                for item in result:
+                    if self.regexp.fullmatch(item) is None:
+                        raise ValueError()
+
+            return result
+
+        except ValueError:
+            msg = f'"{value}" is not a valid list of items'
+            if self.regexp:
+                msg += f" matching the format: {self.regexp_str}"
+
+            self.fail(msg, param, ctx)
+
+
+KeyValue = typing.Dict[str, str]
+
+
+class KeyValueList(List):
+    """
+    List of key-value type for command-line parameters.
+    """
+
+    name = "kvlist"
+
+    def __init__(self, kv_separator=":", list_separator=","):
+        super().__init__(separator=list_separator)
+        self.kv_separator = kv_separator
+
+    def convert(self, value, param, ctx):
+        """
+        Convert input value into list of key-value.
+        """
+        result: KeyValue = {}
+
+        try:
+            kvs = super().convert(value, param, ctx)
+
+            for kv in kvs:
+                k, v = list(map(str.strip, kv.split(self.kv_separator)))
+                result[k] = v
+
+            return result
+
+        except ValueError:
+            self.fail(f'"{value}" is not a valid list of key-value', param, ctx)
+
+
+KeyValues = typing.Dict[str, typing.List[str]]
+
+
+class KeyValuesList(KeyValueList):
+    """
+    List of key-values type for command-line parameters.
+    """
+
+    name = "kvslist"
+
+    def __init__(self, value_separator=",", kv_separator=":", list_separator=";"):
+        super().__init__(kv_separator=kv_separator, list_separator=list_separator)
+        self.value_separator = value_separator
+
+    def convert(self, value, param, ctx):
+        """
+        Convert input value into list of key-values.
+        """
+        result: KeyValues = defaultdict(list)
+
+        try:
+            kvs: KeyValue = super().convert(value, param, ctx)
+
+            for k in kvs.keys():
+                vs = list(map(str.strip, kvs[k].split(self.value_separator)))
+                result[k].extend(vs)
+
+            return dict(result)
+
+        except ValueError:
+            self.fail(f'"{value}" is not a valid list of key-values', param, ctx)
+
+
+class String(StringParamType):
+    """
+    String type for command-line parameters with support of macros and
+    regexp-based validation.
+    """
+
+    name = "string"
+
+    def __init__(self, regexp=None, macros=None):
+        self.regexp_str = regexp
+        self.regexp = re.compile(regexp) if regexp else None
+        self.macros = macros
+
+    def convert(self, value, param, ctx):
+        """
+        Parse input value.
+        """
+        if self.macros:
+            for macro, replacement in self.macros.items():
+                value = value.replace(macro, replacement)
+
+        if self.regexp:
+            if self.regexp.fullmatch(value) is None:
+                msg = f'"{value}" does not match the format: {self.regexp_str}'
+                self.fail(msg, param, ctx)
+
+        return super().convert(value, param, ctx)
+
+
+class TimeSpan(ParamType):
+    """
+    TimeSpan type for command-line parameters.
+    """
+
+    name = "TimeSpan"
+
+    def convert(self, value, param, ctx):
+        """
+        Convert timespan string into seconds.
+        """
+        try:
+            return int(parse_timespan(value))
+        except InvalidTimespan as e:
+            self.fail(f'"{value}" is not a valid timespan: {str(e)}', param, ctx)
+
+
+class JsonParamType(ParamType):
+    """
+    JsonParamType type for command-line parameter for JSON value.
+    """
+
+    name = "json"
+
+    def convert(self, value, param, ctx):
+        try:
+            if re.fullmatch(
+                r'\s*([\[{"].*|true|false|null|\d+(\.\d+)?)\s*',
+                value,
+                re.MULTILINE | re.DOTALL,
+            ):
+                return json.loads(value)
+            return value.strip()
+        except json.JSONDecodeError:
+            self.fail(f'"{value}" is not a valid json value', param, ctx)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,111 @@
+"""
+Cli unit tests.
+"""
+
+from tests.unit.utils import parametrize
+
+from ch_backup import cli
+
+
+@parametrize(
+    {
+        "id": "empty config values",
+        "args": {
+            "values": [],
+            "expected": {},
+        },
+    },
+    {
+        "id": "single config values",
+        "args": {
+            "values": [
+                ("backup", {"path_root": "/root"}),
+            ],
+            "expected": {
+                "backup": {
+                    "path_root": "/root",
+                }
+            },
+        },
+    },
+    {
+        "id": "plain config values",
+        "args": {
+            "values": [
+                ("backup.path_root", "/root"),
+                ("backup.deduplication_age_limit.days", 123),
+                ("backup.keep_freezed_data_on_failure", True),
+            ],
+            "expected": {
+                "backup": {
+                    "path_root": "/root",
+                    "deduplication_age_limit": {
+                        "days": 123,
+                    },
+                    "keep_freezed_data_on_failure": True,
+                }
+            },
+        },
+    },
+    {
+        "id": "complex config values",
+        "args": {
+            "values": [
+                (
+                    "backup",
+                    {
+                        "path_root": None,
+                        "deduplication_age_limit": {
+                            "days": 7,
+                        },
+                    },
+                ),
+                ("backup.path_root", "/root"),
+                ("backup.deduplication_age_limit", {"days": 8}),
+                ("backup.keep_freezed_data_on_failure", True),
+            ],
+            "expected": {
+                "backup": {
+                    "path_root": "/root",
+                    "deduplication_age_limit": {
+                        "days": 8,
+                    },
+                    "keep_freezed_data_on_failure": True,
+                }
+            },
+        },
+    },
+    {
+        "id": "overrode config values",
+        "args": {
+            "values": [
+                ("backup", "not_used_setting"),
+                ("backup", "actual_setting"),
+            ],
+            "expected": {"backup": "actual_setting"},
+        },
+    },
+    {
+        "id": "not uniform config values",
+        "args": {
+            "values": [
+                (
+                    "backup",
+                    {
+                        "path_root": "/root",
+                        "deduplication_age_limit": {
+                            "days": 7,
+                        },
+                    },
+                ),
+                ("backup", "actual_setting"),
+            ],
+            "expected": {
+                "backup": "actual_setting",
+            },
+        },
+    },
+)
+def test_build_cli_cfg_from_config_parameters(values, expected):
+    # pylint: disable=protected-access
+    assert cli._build_cli_cfg_from_config_parameters(values) == expected


### PR DESCRIPTION
It merges default config + file-config + cli-config.
CLI-config has most priority.
And works like:
```
# ch-backup --config-value backup:deduplication_age_limit:days 150 list
...
final config after override and merge:  {'backup': {... 'deduplication_age_limit': {'days': 150} ... }}
...

# ch-backup --config-value backup '{"deduplication_age_limit": 150}' list
...
final config after override and merge:  {'backup': {... 'deduplication_age_limit': {'days': 150} ... }}
...

#ch-backup --config-value backup '{"deduplication_age_limit": 150, "retain_time": {'days': 150}}' --config-value 'backup:retain_time:days' 300 list
...
final config after override and merge:  {'backup': {... 'deduplication_age_limit': {'days': 150}, 'retain_time': {'days': 300} ... }}
...
```