### PR TITLE
Spawn several clickhouse-disks instances for data restoring

### DIFF
--- a/ch_backup/clickhouse/disks.py
+++ b/ch_backup/clickhouse/disks.py
@@ -159,7 +159,7 @@ class ClickHouseTemporaryDisks:
         Copy parts from temporary cloud storage disk to actual.
         """
 
-        # We can use asynchio.run when python3.6 will be depricated.
+        # We can use asynchio.run when python3.6 will be deprecated.
         loop = asyncio.get_event_loop()
         loop.run_until_complete(
             self._copy_part_internal(backup_meta, parts_to_copy, max_proccesses_count)

--- a/ch_backup/clickhouse/disks.py
+++ b/ch_backup/clickhouse/disks.py
@@ -164,7 +164,6 @@ class ClickHouseTemporaryDisks:
         loop.run_until_complete(
             self._copy_part_internal(backup_meta, parts_to_copy, max_proccesses_count)
         )
-        loop.close()
 
     async def _copy_part_internal(
         self,
@@ -201,7 +200,12 @@ class ClickHouseTemporaryDisks:
                 job_index += 1
 
             _, pending = await asyncio.wait(
-                running_proc, return_when=asyncio.FIRST_COMPLETED
+                running_proc,
+                return_when=(
+                    asyncio.ALL_COMPLETED
+                    if job_index == len(parts_to_copy)
+                    else asyncio.FIRST_COMPLETED
+                ),
             )
             running_proc = pending
 

--- a/ch_backup/clickhouse/disks.py
+++ b/ch_backup/clickhouse/disks.py
@@ -4,7 +4,7 @@ Clickhouse-disks controls temporary cloud storage disks management.
 
 import copy
 import os
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from subprocess import PIPE, Popen
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
@@ -174,7 +174,7 @@ class ClickHouseTemporaryDisks:
                 ): part[1].name
                 for part in parts_to_copy
             }
-            for future in futures_to_part:
+            for future in as_completed(futures_to_part):
                 try:
                     future.result()
                 except Exception:

--- a/ch_backup/clickhouse/disks.py
+++ b/ch_backup/clickhouse/disks.py
@@ -159,10 +159,12 @@ class ClickHouseTemporaryDisks:
         Copy parts from temporary cloud storage disk to actual.
         """
 
+        # We can use asynchio.run when python3.6 will be depricated.
         loop = asyncio.get_event_loop()
         loop.run_until_complete(
             self._copy_part_internal(backup_meta, parts_to_copy, max_proccesses_count)
         )
+        loop.close()
 
     async def _copy_part_internal(
         self,

--- a/ch_backup/config.py
+++ b/ch_backup/config.py
@@ -148,6 +148,8 @@ DEFAULT_CONFIG = {
         # The number of processes allocating for data processing. If set to 0, all processing will be performed
         # in the main process.
         "workers": 4,
+        # The number of processes for parts restoring from S3 disks.
+        "cloud_storage_restore_workers": 4,
     },
     "pipeline": {
         # Is asynchronous pipelines used (based on Pypeln library)
@@ -163,6 +165,7 @@ DEFAULT_CONFIG = {
     "loguru": {
         "formatters": {
             "ch-backup": "{time:YYYY-MM-DD HH:mm:ss,SSS} {process.name:11} {process.id:5} [{level:8}] {extra[logger_name]}: {message}",
+            "clickhouse-disks": "{time:YYYY-MM-DD HH:mm:ss,SSS} {extra[tag]} {process.id:5} [{level:8}]: {message}",
         },
         "handlers": {
             "ch-backup": {
@@ -188,7 +191,7 @@ DEFAULT_CONFIG = {
             "clickhouse-disks": {
                 "sink": "/var/log/ch-backup/clickhouse-disks.log",
                 "level": "DEBUG",
-                "format": "ch-backup",
+                "format": "clickhouse-disks",
             },
             "urllib3.connectionpool": {
                 "sink": "/var/log/ch-backup/boto.log",

--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -568,8 +568,8 @@ class TableBackup(BackupManager):
     ) -> None:
         # pylint: disable=too-many-branches
         logging.info("Restoring tables data")
-        cloud_storage_parts = []
         for table_meta in tables:
+            cloud_storage_parts = []
             try:
                 logging.debug(
                     'Running table "{}.{}" data restore',
@@ -625,6 +625,7 @@ class TableBackup(BackupManager):
                             )
                         else:
                             raise
+
                 disks.copy_parts(
                     context.backup_meta,
                     cloud_storage_parts,

--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -632,6 +632,7 @@ class TableBackup(BackupManager):
                     context.config_root["multiprocessing"][
                         "cloud_storage_restore_workers"
                     ],
+                    keep_going,
                 )
 
                 context.backup_layout.wait(keep_going)


### PR DESCRIPTION
Results on large cluster:
```
# Data for restore:
SELECT
    database,
    formatReadableSize(sum(data_compressed_bytes) AS size) AS compressed,
    formatReadableSize(sum(data_uncompressed_bytes) AS usize) AS uncompressed,
    round(usize / size, 2) AS compr_rate,
    sum(rows) AS rows,
    count() AS part_count
FROM system.parts
WHERE (active = 1) AND (database LIKE 'mdb')
GROUP BY database
ORDER BY size DESC

Query id: bc037387-2b88-45ad-b0c7-da014f3dac30

┌─database─┬─compressed─┬─uncompressed─┬─compr_rate─┬─────────rows─┬─part_count─┐
│ mdb      │ 12.96 TiB  │ 137.44 TiB   │      10.61 │ 544020276855 │       1309 │
└──────────┴────────────┴──────────────┴────────────┴──────────────┴────────────┘

# Data on object storage disk:

SELECT
    database,
    formatReadableSize(sum(data_compressed_bytes) AS size) AS compressed,
    formatReadableSize(sum(data_uncompressed_bytes) AS usize) AS uncompressed,
    round(usize / size, 2) AS compr_rate,
    sum(rows) AS rows,
    count() AS part_count
FROM system.parts
WHERE (active = 1) AND (database LIKE 'mdb') AND (disk_name LIKE 'object_storage')
GROUP BY database
ORDER BY size DESC

Query id: 22183836-ff91-4a8e-b992-539e7c09afa2

┌─database─┬─compressed─┬─uncompressed─┬─compr_rate─┬─────────rows─┬─part_count─┐
│ mdb      │ 10.50 TiB  │ 108.10 TiB   │       10.3 │ 440825651603 │        742 │
└──────────┴────────────┴──────────────┴────────────┴──────────────┴────────────┘

```
| version  |  time  | comments   |  
|---|---|---|
| clcikhouse-23.8 + ch_backup_without_parall_copy   | 2514 min |   |  
| clcikhouse-24.1 + ch_backup_with_parall_copy(8 workers)         |  326 min  |  with parallel copy from object storage  and with s3-server-side copy for clickhouse-disks|   

