### PR TITLE
Fixed log record formatting in signal_handler

### DIFF
--- a/ch_backup/cli.py
+++ b/ch_backup/cli.py
@@ -45,7 +45,7 @@ def signal_handler(signum, _frame):
     """
     Logs received signal. Useful for troubleshooting.
     """
-    logging.info("Received signal %d", signum)
+    logging.info("Received signal %s", signum)
     # If a signal handler raises an exception, the exception will be propagated to the main
     # thread and may be raised after any bytecode instruction.
     # https://docs.python.org/3/library/signal.html#note-on-signal-handlers-and-exceptions


### PR DESCRIPTION
It fixes
```
2024-02-17 21:27:53,313 MainProcess 2586266 [INFO    ] ch-backup: Received signal %d
2024-02-17 21:27:53,313 Process-6   2591733 [INFO    ] ch-backup: Received signal %d
2024-02-17 21:27:53,313 Process-8   2591735 [INFO    ] ch-backup: Received signal %d
2024-02-17 21:27:53,313 Process-4   2591731 [INFO    ] ch-backup: Received signal %d
2024-02-17 21:27:53,313 Process-1   2591728 [INFO    ] ch-backup: Received signal %d
2024-02-17 21:27:53,313 Process-2   2591729 [INFO    ] ch-backup: Received signal %d
2024-02-17 21:27:53,313 Process-5   2591732 [INFO    ] ch-backup: Received signal %d
2024-02-17 21:27:53,313 Process-3   2591730 [INFO    ] ch-backup: Received signal %d
2024-02-17 21:27:53,313 Process-7   2591734 [INFO    ] ch-backup: Received signal %d
```