### PR TITLE
Fix logging

### DIFF
--- a/ch_backup/cli.py
+++ b/ch_backup/cli.py
@@ -46,7 +46,7 @@ def signal_handler(signum, _frame):
     """
     Logs received signal. Useful for troubleshooting.
     """
-    logging.info("Received signal %s", signum)
+    logging.info(f"Received signal {signum}")
     # If a signal handler raises an exception, the exception will be propagated to the main
     # thread and may be raised after any bytecode instruction.
     # https://docs.python.org/3/library/signal.html#note-on-signal-handlers-and-exceptions

--- a/ch_backup/clickhouse/disks.py
+++ b/ch_backup/clickhouse/disks.py
@@ -6,7 +6,8 @@ import copy
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from subprocess import PIPE, Popen
-from typing import Any, Dict, List, Optional, Tuple
+from types import TracebackType
+from typing import Any, Dict, List, Optional, Tuple, Type
 from urllib.parse import urlparse
 
 import xmltodict
@@ -88,10 +89,15 @@ class ClickHouseTemporaryDisks:
         )
         return self
 
-    def __exit__(self, exc_type, *args, **kwargs):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> bool:
         if exc_type is not None:
             logging.warning(
-                f'Omitting tmp cloud storage disk cleanup due to exception: "{exc_type}"'
+                f'Omitting tmp cloud storage disk cleanup due to exception: "{exc_type.__name__}: {value}"'
             )
             return False
 
@@ -103,6 +109,7 @@ class ClickHouseTemporaryDisks:
                 return True
             except FileNotFoundError:
                 pass
+        return True
 
     def _render_disks_config(self, path, disks):
         with open(path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
`Omitting tmp cloud storage disk cleanup due to exception: "<class 'ch_backup.clickhouse.disks.ClickHouseDisksException'>"` changed to `Omitting tmp cloud storage disk cleanup due to exception: "ClickHouseDisksException: clickhouse-disks call failed with exitcode: 0"`

`Received signal %s` changed to `Received signal 1`