### PR TITLE
Fixed ruff warnings

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,3 +1,4 @@
+[lint]
 select = ["E", "F", "W", "A"]
 
 ignore = [
@@ -5,5 +6,5 @@ ignore = [
     "E501",  # "Line too long"
 ]
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "__init__.py" = ["F401"]  # "Unused import"


### PR DESCRIPTION
The fix for the following warning:
```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `.ruff.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
```