### PR TITLE
Docker Compose v2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,5 @@ PyHamcrest
 hypothesis
 behave
 docker<8.0
-docker-compose<1.28
-websocket-client<2.0  # required for docker-compose<1.28
 Jinja2
 deepdiff<7.1.0

--- a/tests/integration/modules/compose.py
+++ b/tests/integration/modules/compose.py
@@ -182,7 +182,7 @@ def _call_compose(conf: dict, *, command: str, project_name: str = None) -> None
     """
     Execute docker-compose action by invoking `docker-compose`.
     """
-    shell_command = f"docker-compose --file {_config_path(conf)}"
+    shell_command = f"docker compose --file {_config_path(conf)}"
     if project_name:
         shell_command += f" -p {project_name}"
     shell_command += f" {command}"


### PR DESCRIPTION
- Add support of Docker Compose v2
- Drop support and usage of deprecated Docker Compose v1

https://docs.docker.com/compose/migrate/