### PR TITLE
Set 60 seconds interval between shapshot memory in workers

### DIFF
--- a/ch_backup/storage/async_pipeline/pipeline_executor.py
+++ b/ch_backup/storage/async_pipeline/pipeline_executor.py
@@ -221,7 +221,7 @@ class PipelineExecutor:
         """
 
         if is_async and self._exec_pool:
-            return self._exec_pool.submit(job_id, profile(10)(pipeline), callback)
+            return self._exec_pool.submit(job_id, profile(10, 60)(pipeline), callback)
 
         result = pipeline()
         if callback:


### PR DESCRIPTION
Fix for https://github.com/yandex/ch-backup/pull/108
Before code took memory snapshot after each task in worker, as result time for backups increased in dozens times (like 0.5 second for upload and 10 seconds for snapshot)
This should be in that PR as mentioned in comment "once per 60 seconds", but limit was forgotten in that time.