### PR TITLE
Revomed usage of system libsodium during PyNaCl installation

### DIFF
--- a/Dockerfile-deb-build
+++ b/Dockerfile-deb-build
@@ -27,7 +27,7 @@ RUN set -ex \
     # Configure locales
     && locale-gen en_US.UTF-8 \
     && update-locale LANG=en_US.UTF-8 \
-    # Ensure that `python` refers to `python3` so that poetry works. 
+    # Ensure that `python` refers to `python3` so that poetry works.
     # It makes sense for ubuntu:18.04
     && ln -sf /usr/bin/python3 /usr/bin/python
 
@@ -35,9 +35,6 @@ RUN set -ex \
 VOLUME /src
 WORKDIR /src
 
-# For compiling PyNACL library, which is used by ch-backup
-# See https://pynacl.readthedocs.io/en/latest/install/#linux-source-build
-ENV SODIUM_INSTALL=system
 ENV PYTHON=/usr/bin/python3
 
 CMD ["make", "build-deb-package-local"]


### PR DESCRIPTION
On bionic it fails with:

```
ImportError: /src/debian/ch-backup/opt/yandex/ch-backup/lib/python3.6/site-packages/nacl/_sodium.abi3.so: undefined symbol: crypto_core_ed25519_nonreducedscalarbytes
Makefile:113: recipe for target 'install' failed
```