### PR TITLE
Revert "Update boto3 requirement from <1.19 to <1.28 (#140)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>2.19
-boto3<1.28
+boto3<1.19
 botocore<1.35
 psutil
 PyYAML<5.4


### PR DESCRIPTION
This reverts commit 3f4b09513c6fef7cd2a476e715cc4fc430ac9524.

boto3 update broke backup creation. 
```
2024-04-28 01:49:10,343 MainProcess 61090 [DEBUG   ] ch-backup: Exponential retry ch_backup.storage.engine.s3.s3_engine.S3StorageEngine.list_dir in 114.20797226824341, attempt: 28, reason
: Failed to make S3 operation: SSL validation failed for https://yandexcloud-dbaas-e4uk0dki9t75jmopn6up.storage.cloud-preprod.yandex.net/?prefix=ch_backup%2Fe4uk0dki9t75jmopn6up%2Fshard1%
2F&delimiter=%2F&encoding-type=url [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)
2024-04-28 01:51:04,634 MainProcess 61090 [DEBUG   ] ch-backup: Exponential retry ch_backup.storage.engine.s3.s3_engine.S3StorageEngine.list_dir in 126.46979622430322, attempt: 29, reason
: Failed to make S3 operation: SSL validation failed for https://yandexcloud-dbaas-e4uk0dki9t75jmopn6up.storage.cloud-preprod.yandex.net/?prefix=ch_backup%2Fe4uk0dki9t75jmopn6up%2Fshard1%
2F&delimiter=%2F&encoding-type=url [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)
2024-04-28 01:53:11,147 MainProcess 61090 [DEBUG   ] ch-backup: Command 'backup' failed
```

