### PR TITLE
Revert "Update botocore requirement from <1.22 to <1.35"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests>2.19
 boto3<1.19
-botocore<1.35
+botocore<1.22
 psutil
 PyYAML<5.4
 PyNaCl==1.2.1


### PR DESCRIPTION
Reverts yandex/ch-backup#125

Continuation of https://github.com/yandex/ch-backup/pull/146