### PR TITLE
Use ijson for backup metadata in deduplication

### DIFF
--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -328,6 +328,16 @@ class BackupLayout:
         """
         Reload backup metadata.
         """
+        return BackupMetadata.load_json(
+            self.reload_backup_raw(backup, use_light_meta, "utf-8")
+        )
+
+    def reload_backup_raw(
+        self, backup: BackupMetadata, use_light_meta: bool = False, encoding: str = None
+    ) -> str | bytes | None:  # pylint: disable=unsupported-binary-operation
+        """
+        Reload backup metadata as raw bytes.
+        """
         path = (
             self._backup_light_metadata_path(backup.name)
             if use_light_meta
@@ -335,8 +345,7 @@ class BackupLayout:
         )
 
         try:
-            data = self._storage_loader.download_data(path)
-            return BackupMetadata.load_json(data)
+            return self._storage_loader.download_data(path, encoding=encoding)
         except Exception as e:
             raise StorageError("Failed to download backup metadata") from e
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pypeln==0.4.9
 dataclasses>=0.7,<0.8; python_version <"3.7"  # required for pypeln==0.4.9
 typing_extensions>=3.7.4,<4.0; python_version <"3.8"  # required for pypeln==0.4.9
 loguru
+ijson

--- a/tests/unit/test_deduplication.py
+++ b/tests/unit/test_deduplication.py
@@ -20,6 +20,7 @@ from ch_backup.backup.deduplication import (
     collect_dedup_references_for_batch_backup_deletion,
 )
 from ch_backup.backup.metadata import BackupState
+from ch_backup.backup.metadata.backup_metadata import BackupMetadata
 from ch_backup.backup_context import BackupContext
 from ch_backup.clickhouse.models import Database
 
@@ -582,4 +583,8 @@ def test_collect_dedup_references_for_batch_backup_deletion(
 def layout_mock():
     layout = MagicMock()
     layout.reload_backup = lambda backup, use_light_meta: backup
+    # Passing str to ijson causes deprecation warning
+    layout.reload_backup_raw = lambda backup, use_light_meta: bytes(
+        BackupMetadata.dump_json(backup), "utf-8"
+    )
     return layout


### PR DESCRIPTION
Previously, all backup metadata was loaded as json. Now we load data for one database at a time.
`gc.collect` is added just in case after each database is processed, but maybe it is not necessary now.
