### PR TITLE
Fix  CI

### DIFF
--- a/images/clickhouse/Dockerfile
+++ b/images/clickhouse/Dockerfile
@@ -40,6 +40,7 @@ COPY staging/images/{{ instance_name }}/config/clickhouse-keyring.gpg /usr/share
 RUN cd ${CH_TMP_DIR} && \
     pip3 install -r requirements.txt && \
     mkdir -p /etc/apt/sources.list.d && \
+    apt-get update -qq && \
     echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb stable main" | tee /etc/apt/sources.list.d/clickhouse.list && \
     apt-get update -qq && \
     if [ "${CLICKHOUSE_VERSION}" = "latest" ]; then \


### PR DESCRIPTION
Fix for:
```
15.33 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
[2984](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:2985)
15.44 deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb stable main
[2985](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:2986)
16.59 E: Failed to fetch https://packages.clickhouse.com/deb/dists/stable/main/binary-amd64/Packages.gz  File has unexpected size (131346 != 130457). Mirror sync in progress? [IP: 172.66.40.249 443]
[2986](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:2987)
16.59    Hashes of expected file:
[2987](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:2988)
16.59     - Filesize:130457 [weak]
[2988](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:2989)
16.59     - SHA256:0d3f191a5bfa709300afd5002525f0c43430878bff3d7b1b0740f1589a33f82e
[2989](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:2990)
16.59     - SHA1:e4b6d69ef6979ea6cb476e26bf8a20b2043b04cb [weak]
[2990](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:2991)
16.59     - MD5Sum:db3da8d69af37e27b9dbdb2ffd9e0764 [weak]
[2991](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:2992)
16.59    Release file created at: Fri, 07 Jun 2024 10:57:43 +0000
[2992](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:2993)
16.59 E: Some index files failed to download. They have been ignored, or old ones used instead.
[2993](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:2994)
------
[2994](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:2995)
Dockerfile:40
[2995](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:2996)
--------------------
[2996](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:2997)
  39 |     COPY staging/images/clickhouse02/config/clickhouse-keyring.gpg /usr/share/keyrings/clickhouse-keyring.gpg
[2997](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:2998)
  40 | >>> RUN cd ${CH_TMP_DIR} && \
[2998](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:2999)
  41 | >>>     pip3 install -r requirements.txt && \
[2999](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3000)
  42 | >>>     mkdir -p /etc/apt/sources.list.d && \
[3000](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3001)
  43 | >>>     echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb stable main" | tee /etc/apt/sources.list.d/clickhouse.list && \
[3001](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3002)
  44 | >>>     apt-get update -qq && \
[3002](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3003)
  45 | >>>     if [ "${CLICKHOUSE_VERSION}" = "latest" ]; then \
[3003](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3004)
  46 | >>>         DEBIAN_FRONTEND=noninteractive apt-get install -y \
[3004](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3005)
  47 | >>>             clickhouse-server \
[3005](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3006)
  48 | >>>             clickhouse-client \
[3006](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3007)
  49 | >>>             clickhouse-common-static; \
[3007](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3008)
  50 | >>>     else \
[3008](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3009)
  51 | >>>         DEBIAN_FRONTEND=noninteractive apt-get install -y \
[3009](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3010)
  52 | >>>             clickhouse-server=${CLICKHOUSE_VERSION} \
[3010](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3011)
  53 | >>>             clickhouse-client=${CLICKHOUSE_VERSION} \
[3011](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3012)
  54 | >>>             clickhouse-common-static=${CLICKHOUSE_VERSION}; \
[3012](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3013)
  55 | >>>     fi && \
[3013](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3014)
  56 | >>>     rm -rf /var/lib/apt/lists/* /var/cache/debconf && \
[3014](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3015)
  57 | >>>     apt-get clean
[3015](https://github.com/yandex/ch-backup/actions/runs/9501816235/job/26188347769#step:5:3016)
  58 |
```