### PR TITLE
Added support for python3.12

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -63,6 +63,8 @@ jobs:
           clickhouse: "latest"
         - python: "3.11"
           clickhouse: "latest"
+        - python: "3.12"
+          clickhouse: "latest"
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests>2.19,<2.29
-boto3<1.19
-botocore<1.22
+boto3<1.19; python_version <"3.12"
+botocore<1.22; python_version <"3.12"
 psutil
 PyYAML<5.4
 PyNaCl==1.2.1
@@ -15,3 +15,7 @@ pypeln==0.4.9
 dataclasses>=0.7,<0.8; python_version <"3.7"  # required for pypeln==0.4.9
 typing_extensions>=3.7.4,<4.0; python_version <"3.8"  # required for pypeln==0.4.9
 loguru
+# for python3.12+
+setuptools; python_version >="3.12"  # instead of python3-setuptools package
+boto3<1.21; python_version >="3.12"
+botocore<1.24; python_version >="3.12"

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Database",
         "Typing :: Typed",
     ],


### PR DESCRIPTION
Just copied already tested by us version of working dependencies for python3.12 from https://github.com/yandex/ch-backup/pull/152/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552

Also added test for the latest CH version.