### PR TITLE
Escape database, table and udf names for S3 paths

### DIFF
--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -616,7 +616,7 @@ class BackupLayout:
         self, path_function: Callable, *args: Any, **kwargs: Any
     ) -> str:
         """
-        Return escaped path if if exists. Otherwise return regular path.
+        Return escaped path if it exists. Otherwise return regular path.
         """
         path = path_function(*args, escape_names=True, **kwargs)
         if self._storage_loader.path_exists(path, is_dir=True):

--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -246,7 +246,7 @@ class BackupLayout:
         """
         Download user defined function create statement.
         """
-        remote_path = self._try_get_escaped_path(
+        remote_path = self._get_escaped_if_exists(
             _udf_data_path, backup_meta.path, filename
         )
         return self._storage_loader.download_data(remote_path, encryption=True)
@@ -421,7 +421,7 @@ class BackupLayout:
 
         os.makedirs(fs_part_path, exist_ok=True)
 
-        remote_dir_path = self._try_get_escaped_path(
+        remote_dir_path = self._get_escaped_if_exists(
             _part_path,
             part.link or backup_meta.path,
             part.database,
@@ -463,7 +463,7 @@ class BackupLayout:
         Check availability of part data in storage.
         """
         try:
-            remote_dir_path = self._try_get_escaped_path(
+            remote_dir_path = self._get_escaped_if_exists(
                 _part_path,
                 part.link or backup_path,
                 part.database,
@@ -553,7 +553,7 @@ class BackupLayout:
 
         deleting_files: List[str] = []
         for part in parts:
-            part_path = self._try_get_escaped_path(
+            part_path = self._get_escaped_if_exists(
                 _part_path,
                 part.link or backup_meta.path,
                 part.database,
@@ -612,7 +612,7 @@ class BackupLayout:
             tar_size, self._encryption_chunk_size, self._encryption_metadata_size
         )
 
-    def _try_get_escaped_path(
+    def _get_escaped_if_exists(
         self, path_function: Callable, *args: Any, **kwargs: Any
     ) -> str:
         """

--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -4,7 +4,7 @@ Management of backup data layout.
 
 import os
 from pathlib import Path
-from typing import Callable, List, Optional, Sequence
+from typing import Any, Callable, List, Optional, Sequence
 from urllib.parse import quote
 
 from ch_backup import logging
@@ -246,7 +246,9 @@ class BackupLayout:
         """
         Download user defined function create statement.
         """
-        remote_path = _udf_data_path(backup_meta.path, filename)
+        remote_path = self._try_get_escaped_path(
+            _udf_data_path, backup_meta.path, filename
+        )
         return self._storage_loader.download_data(remote_path, encryption=True)
 
     def get_local_nc_create_statement(self, nc_name: str) -> Optional[str]:
@@ -419,8 +421,12 @@ class BackupLayout:
 
         os.makedirs(fs_part_path, exist_ok=True)
 
-        remote_dir_path = _part_path(
-            part.link or backup_meta.path, part.database, part.table, part.name
+        remote_dir_path = self._try_get_escaped_path(
+            _part_path,
+            part.link or backup_meta.path,
+            part.database,
+            part.table,
+            part.name,
         )
 
         if part.tarball:
@@ -457,8 +463,12 @@ class BackupLayout:
         Check availability of part data in storage.
         """
         try:
-            remote_dir_path = _part_path(
-                part.link or backup_path, part.database, part.table, part.name
+            remote_dir_path = self._try_get_escaped_path(
+                _part_path,
+                part.link or backup_path,
+                part.database,
+                part.table,
+                part.name,
             )
             remote_files = self._storage_loader.list_dir(remote_dir_path)
 
@@ -543,8 +553,12 @@ class BackupLayout:
 
         deleting_files: List[str] = []
         for part in parts:
-            part_path = _part_path(
-                part.link or backup_meta.path, part.database, part.table, part.name
+            part_path = self._try_get_escaped_path(
+                _part_path,
+                part.link or backup_meta.path,
+                part.database,
+                part.table,
+                part.name,
             )
             logging.debug("Deleting data part {}", part_path)
             if part.tarball:
@@ -598,6 +612,17 @@ class BackupLayout:
             tar_size, self._encryption_chunk_size, self._encryption_metadata_size
         )
 
+    def _try_get_escaped_path(
+        self, path_function: Callable, *args: Any, **kwargs: Any
+    ) -> str:
+        """
+        Return escaped path if if exists. Otherwise return regular path.
+        """
+        path = path_function(*args, escape_names=True, **kwargs)
+        if self._storage_loader.path_exists(path, is_dir=True):
+            return path
+        return path_function(*args, escape_names=False, **kwargs)
+
 
 def _access_control_data_path(backup_path: str, file_name: str) -> str:
     """
@@ -606,10 +631,12 @@ def _access_control_data_path(backup_path: str, file_name: str) -> str:
     return os.path.join(backup_path, "access_control", file_name)
 
 
-def _udf_data_path(backup_path: str, udf_file: str) -> str:
+def _udf_data_path(backup_path: str, udf_file: str, escape_names: bool = True) -> str:
     """
     Return S3 path to UDF data
     """
+    if escape_names:
+        return os.path.join(backup_path, "udf", _quote(udf_file))
     return os.path.join(backup_path, "udf", udf_file)
 
 
@@ -636,10 +663,20 @@ def _named_collections_data_path(backup_path: str, nc_name: str) -> str:
     return os.path.join(backup_path, "named_collections", _quote(nc_name) + ".sql")
 
 
-def _part_path(backup_path: str, db_name: str, table_name: str, part_name: str) -> str:
+def _part_path(
+    backup_path: str,
+    db_name: str,
+    table_name: str,
+    part_name: str,
+    escape_names: bool = True,
+) -> str:
     """
     Return S3 path to data part.
     """
+    if escape_names:
+        return os.path.join(
+            backup_path, "data", _quote(db_name), _quote(table_name), part_name
+        )
     return os.path.join(backup_path, "data", db_name, table_name, part_name)
 
 

--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -4,7 +4,7 @@ Management of backup data layout.
 
 import os
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Sequence
+from typing import Callable, List, Optional, Sequence
 from urllib.parse import quote
 
 from ch_backup import logging
@@ -246,9 +246,8 @@ class BackupLayout:
         """
         Download user defined function create statement.
         """
-        remote_path = self._try_get_escaped_path(
-            _udf_data_path, backup_meta.path, filename
-        )
+        remote_path = _udf_data_path(backup_meta.path, filename, escape_names=False)
+        remote_path = self._get_escaped_if_exists(remote_path)
         return self._storage_loader.download_data(remote_path, encryption=True)
 
     def get_local_nc_create_statement(self, nc_name: str) -> Optional[str]:
@@ -421,13 +420,14 @@ class BackupLayout:
 
         os.makedirs(fs_part_path, exist_ok=True)
 
-        remote_dir_path = self._try_get_escaped_path(
-            _part_path,
+        remote_dir_path = _part_path(
             part.link or backup_meta.path,
             part.database,
             part.table,
             part.name,
+            escape_names=False,
         )
+        remote_dir_path = self._get_escaped_if_exists(remote_dir_path)
 
         if part.tarball:
             remote_path = os.path.join(remote_dir_path, f"{part.name}.tar")
@@ -463,13 +463,14 @@ class BackupLayout:
         Check availability of part data in storage.
         """
         try:
-            remote_dir_path = self._try_get_escaped_path(
-                _part_path,
+            remote_dir_path = _part_path(
                 part.link or backup_path,
                 part.database,
                 part.table,
                 part.name,
+                escape_names=False,
             )
+            remote_dir_path = self._get_escaped_if_exists(remote_dir_path)
             remote_files = self._storage_loader.list_dir(remote_dir_path)
 
             if remote_files == [f"{part.name}.tar"]:
@@ -553,13 +554,14 @@ class BackupLayout:
 
         deleting_files: List[str] = []
         for part in parts:
-            part_path = self._try_get_escaped_path(
-                _part_path,
+            part_path = _part_path(
                 part.link or backup_meta.path,
                 part.database,
                 part.table,
                 part.name,
+                escape_names=False,
             )
+            part_path = self._get_escaped_if_exists(part_path)
             logging.debug("Deleting data part {}", part_path)
             if part.tarball:
                 deleting_files.append(os.path.join(part_path, f"{part.name}.tar"))
@@ -612,16 +614,14 @@ class BackupLayout:
             tar_size, self._encryption_chunk_size, self._encryption_metadata_size
         )
 
-    def _try_get_escaped_path(
-        self, path_function: Callable, *args: Any, **kwargs: Any
-    ) -> str:
+    def _get_escaped_if_exists(self, unescaped_path: str) -> str:
         """
         Return escaped path if it exists. Otherwise return regular path.
         """
-        path = path_function(*args, escape_names=True, **kwargs)
-        if self._storage_loader.path_exists(path, is_dir=True):
-            return path
-        return path_function(*args, escape_names=False, **kwargs)
+        escaped_path = _quote(unescaped_path)
+        if self._storage_loader.path_exists(escaped_path, is_dir=True):
+            return escaped_path
+        return unescaped_path
 
 
 def _access_control_data_path(backup_path: str, file_name: str) -> str:

--- a/ch_backup/storage/engine/base.py
+++ b/ch_backup/storage/engine/base.py
@@ -55,7 +55,7 @@ class StorageEngine(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def path_exists(self, remote_path: str) -> bool:
+    def path_exists(self, remote_path: str, is_dir: bool = False) -> bool:
         """
         Check if remote path exists.
         """

--- a/ch_backup/storage/loader.py
+++ b/ch_backup/storage/loader.py
@@ -203,11 +203,11 @@ class StorageLoader:
             remote_path, recursive=recursive, absolute=absolute
         )
 
-    def path_exists(self, remote_path: str) -> bool:
+    def path_exists(self, remote_path: str, is_dir: bool = False) -> bool:
         """
         Check whether a remote path exists or not.
         """
-        return self._engine.path_exists(remote_path)
+        return self._engine.path_exists(remote_path, is_dir)
 
     def get_file_size(self, remote_path: str) -> int:
         """

--- a/tests/integration/modules/ch_backup.py
+++ b/tests/integration/modules/ch_backup.py
@@ -6,6 +6,7 @@ import json
 import os
 from copy import copy
 from typing import Sequence, Set, Union
+from urllib.parse import quote
 
 import yaml
 
@@ -172,8 +173,8 @@ class Backup:
                     part_path = os.path.join(
                         part_obj.get("link") or backup_path,
                         "data",
-                        db_name,
-                        table_name,
+                        _quote(db_name),
+                        _quote(table_name),
                         part_name,
                     )
                     if part_obj.get("tarball", False):
@@ -443,3 +444,12 @@ def get_version() -> str:
     """
     with open("ch_backup/version.txt", encoding="utf-8") as f:
         return f.read().strip()
+
+
+def _quote(value: str) -> str:
+    return quote(value, safe="").translate(
+        {
+            ord("."): "%2E",
+            ord("-"): "%2D",
+        }
+    )


### PR DESCRIPTION
Unescaped paths may cause some errors with s3 client.
Check if escaped path exists is added for backward compatibility with old backups. `path_exists` was working only for files, so I added another method for directories.