### PR TITLE
Check cloud storage source bucket if backup contains table data

### DIFF
--- a/ch_backup/ch_backup.py
+++ b/ch_backup/ch_backup.py
@@ -229,7 +229,7 @@ class ClickhouseBackup:
 
         if (
             cloud_storage_source_bucket is None
-            and not sources.schema_only
+            and sources.data
             and not skip_cloud_storage
         ):
             if self._context.backup_meta.cloud_storage.enabled:


### PR DESCRIPTION
Previously it was required to have cloud storage enabled even for `ch-backup restore LAST --udf` command, but cloud storage in that case is not needed