### PR TITLE
Freeze and backup tables at the same time

### DIFF
--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -122,61 +122,40 @@ class TableBackup(BackupManager):
                 )
             )
 
-            freezed_tables = self._freeze_tables(
-                context, db, tables_, backup_name, schema_only, freeze_threads
-            )
+            # Create shadow/increment.txt if not exists manually to avoid
+            # race condition with parallel freeze
+            context.ch_ctl.create_shadow_increment()
+            futures: List[Future] = []
+            with ThreadPoolExecutor(max_workers=freeze_threads) as pool:
+                for table in tables_:
+                    future = pool.submit(
+                        TableBackup._freeze_table,
+                        context,
+                        db,
+                        table,
+                        backup_name,
+                        schema_only,
+                    )
+                    futures.append(future)
 
-            logging.debug('All tables from "{}" are frozen', db.name)
+                for future in as_completed(futures):
+                    table_and_create_statement = future.result()
+                    if table_and_create_statement is not None:
+                        table, create_statement = table_and_create_statement
+                        self._backup_freezed_table(
+                            context,
+                            db,
+                            table,
+                            backup_name,
+                            schema_only,
+                            mtimes,
+                            create_statement,
+                        )
 
-            for table, create_statement in freezed_tables:
-                self._backup_freezed_table(
-                    context,
-                    db,
-                    table,
-                    backup_name,
-                    schema_only,
-                    mtimes,
-                    create_statement,
-                )
-
+            context.backup_layout.wait()
             context.ch_ctl.remove_freezed_data()
 
         context.backup_layout.upload_backup_metadata(context.backup_meta)
-
-    @staticmethod
-    def _freeze_tables(
-        context: BackupContext,
-        db: Database,
-        tables: Sequence[Table],
-        backup_name: str,
-        schema_only: bool,
-        threads: int,
-    ) -> List[Tuple[Table, bytes]]:
-        """
-        Freeze tables in parallel.
-        """
-        # Create shadow/increment.txt if not exists manually to avoid
-        # race condition with parallel freeze
-        context.ch_ctl.create_shadow_increment()
-        futures: List[Future] = []
-        with ThreadPoolExecutor(max_workers=threads) as pool:
-            for table in tables:
-                future = pool.submit(
-                    TableBackup._freeze_table,
-                    context,
-                    db,
-                    table,
-                    backup_name,
-                    schema_only,
-                )
-                futures.append(future)
-
-            result: List[Tuple[Table, bytes]] = []
-            for future in as_completed(futures):
-                table_and_statement = future.result()
-                if table_and_statement is not None:
-                    result.append(table_and_statement)
-            return result
 
     @staticmethod
     def _freeze_table(

--- a/ch_backup/storage/async_pipeline/base_pipeline/exec_pool.py
+++ b/ch_backup/storage/async_pipeline/base_pipeline/exec_pool.py
@@ -101,4 +101,4 @@ class ExecPool:
         """
         Shutdown pool explicitly to prevent the program from hanging in case of ungraceful termination.
         """
-        self.shutdown()
+        self.shutdown(graceful=False)

--- a/ch_backup/storage/async_pipeline/base_pipeline/exec_pool.py
+++ b/ch_backup/storage/async_pipeline/base_pipeline/exec_pool.py
@@ -31,6 +31,9 @@ class ExecPool:
     def __init__(self, executor: Executor) -> None:
         self._future_to_job: Dict[Future, Job] = {}
         self._pool = executor
+        # It is necessary to start all processes while there are no running threads
+        # Used to freeze and backup tables at the same time
+        self._start_processes()
 
     def shutdown(self, graceful: bool = True) -> None:
         """
@@ -54,6 +57,14 @@ class ExecPool:
 
         future = self._pool.submit(func, *args, **kwargs)
         self._future_to_job[future] = Job(job_id, callback)
+
+    @staticmethod
+    def _start():
+        return
+
+    def _start_processes(self):
+        future = self._pool.submit(ExecPool._start)
+        future.result()
 
     def wait_all(self, keep_going: bool = False) -> None:
         """

--- a/ch_backup/storage/async_pipeline/base_pipeline/exec_pool.py
+++ b/ch_backup/storage/async_pipeline/base_pipeline/exec_pool.py
@@ -101,4 +101,7 @@ class ExecPool:
         """
         Shutdown pool explicitly to prevent the program from hanging in case of ungraceful termination.
         """
-        self.shutdown(graceful=False)
+        try:
+            self.shutdown(graceful=True)
+        except Exception:  # nosec B110
+            pass


### PR DESCRIPTION
Using processes with threads leads to deadlock when process inherits the lock that is already acquired by some thread.
By initializing processes before any freeze threads are started we can evade deadlock with logging. 
