### PR TITLE
DROP instead of TRUNCATE deduplication_info table

### DIFF
--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -1010,7 +1010,7 @@ class ClickhouseCTL:
             )
         )
         self._ch_client.query(
-            TRUNCATE_TABLE_IF_EXISTS_SQL.format(
+            DROP_TABLE_IF_EXISTS_SQL.format(
                 db_name=escape(self._backup_config["system_database"]),
                 table_name="_deduplication_info",
             )


### PR DESCRIPTION
`deduplication_info` is a temporal table and recreating it is safe. Also this fixes the case when table schema is changed because before usage it is recreated.