### PR TITLE
Log table name while freeze exception

### DIFF
--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -194,7 +194,7 @@ class TableBackup(BackupManager):
                 context.ch_ctl.freeze_table(backup_name, table)
             except ClickhouseError:
                 if context.ch_ctl.does_table_exist(table.database, table.name):
-                    logging.debug(
+                    logging.error(
                         'Cannot freeze table "{}"."{}"',
                         table.database,
                         table.name,

--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -194,6 +194,11 @@ class TableBackup(BackupManager):
                 context.ch_ctl.freeze_table(backup_name, table)
             except ClickhouseError:
                 if context.ch_ctl.does_table_exist(table.database, table.name):
+                    logging.debug(
+                        'Cannot freeze table "{}"."{}"',
+                        table.database,
+                        table.name,
+                    )
                     raise
 
                 logging.warning(


### PR DESCRIPTION
Before raise and log original exception from ClickHouse, let's log database's and table's names.
It seems a problem to find in logs on what table freeze query failed because of parallel execution of freeze queries.