### PR TITLE
[MDB-32251] Skip access checks for cloud storage disk of source cluster

### DIFF
--- a/ch_backup/clickhouse/disks.py
+++ b/ch_backup/clickhouse/disks.py
@@ -159,6 +159,7 @@ class ClickHouseTemporaryDisks:
             )
 
         disk_config["endpoint"] = tmp_disk_enpoint
+
         disks_config = {tmp_disk_name: disk_config}
 
         request_timeout_ms = int(disk_config.get("request_timeout_ms", 0))
@@ -176,6 +177,8 @@ class ClickHouseTemporaryDisks:
                 self._disks[disk_name]["request_timeout_ms"] = str(
                     CH_OBJECT_STORAGE_REQUEST_TIMEOUT_MS
                 )
+
+        disks_config[tmp_disk_name]["skip_access_check"] = str(True).lower()
 
         self._render_disks_config(
             _get_config_path(self._config_dir, tmp_disk_name),

--- a/tests/unit/test_disks.py
+++ b/tests/unit/test_disks.py
@@ -49,6 +49,7 @@ write_result = ""
                       <access_key_id>AKIAACCESSKEY</access_key_id>
                       <secret_access_key>SecretAccesskey</secret_access_key>
                       <request_timeout_ms>3600000</request_timeout_ms>
+                      <skip_access_check>true</skip_access_check>
                     </object_storage_source>
                     <object_storage>
                       <request_timeout_ms replace="replace">3600000</request_timeout_ms>
@@ -94,6 +95,7 @@ write_result = ""
                       <access_key_id>AKIAACCESSKEY</access_key_id>
                       <secret_access_key>SecretAccesskey</secret_access_key>
                       <request_timeout_ms>3600000</request_timeout_ms>
+                      <skip_access_check>true</skip_access_check>
                     </object_storage_source>
                     <object_storage>
                       <request_timeout_ms replace="replace">3600000</request_timeout_ms>
@@ -139,6 +141,7 @@ write_result = ""
                       <access_key_id>AKIAACCESSKEY</access_key_id>
                       <secret_access_key>SecretAccesskey</secret_access_key>
                       <request_timeout_ms>7200000</request_timeout_ms>
+                      <skip_access_check>true</skip_access_check>
                     </object_storage_source>
                   </disks>
                 </storage_configuration>


### PR DESCRIPTION
While restoring cluster we do not need any writes operation to source cluster's cloud storage disk.
So storage credentials could have "Read Only" permission.
But by default CH checks read/write operations to disks while startup - lets skip it.