### PR TITLE
construct named collections definition from system table

### DIFF
--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -242,21 +242,18 @@ class BackupLayout:
         return True
 
     def upload_named_collections_create_statement(
-        self, backup_name: str, nc_name: str
+        self, backup_name: str, nc_name: str, nc_data: str
     ) -> None:
         """
         Upload named collection create statement file.
         """
-        local_path = os.path.join(
-            self._named_collections_path, f"{escape_metadata_file_name(nc_name)}.sql"
-        )
         remote_path = _named_collections_data_path(
             self.get_backup_path(backup_name), nc_name
         )
         try:
             logging.debug('Uploading named collection create statement "{}"', nc_name)
-            self._storage_loader.upload_file(
-                local_path, remote_path=remote_path, encryption=True
+            self._storage_loader.upload_data(
+                data=nc_data, remote_path=remote_path, encryption=True
             )
         except Exception as e:
             msg = f"Failed to create async upload of {remote_path}"

--- a/ch_backup/logic/named_collections.py
+++ b/ch_backup/logic/named_collections.py
@@ -29,10 +29,12 @@ class NamedCollectionsBackup(BackupManager):
         for nc_name in nc:
             context.backup_meta.add_named_collection(nc_name)
 
-        logging.debug("Performing named collections backup for: {}", " ,".join(nc))
-        for nc_name in nc:
+        logging.debug(
+            "Performing named collections backup for: {}", " ,".join(nc.keys())
+        )
+        for nc_name, nc_data in nc.items():
             context.backup_layout.upload_named_collections_create_statement(
-                context.backup_meta.name, nc_name
+                context.backup_meta.name, nc_name, nc_data
             )
 
     def restore(self, context: BackupContext) -> None:

--- a/tests/integration/features/named_collections.feature
+++ b/tests/integration/features/named_collections.feature
@@ -11,8 +11,8 @@ Feature: Backup and restore functionality of named collections
     CREATE NAMED COLLECTION test_s3_nc AS
       access_key_id = 'AKIAIOSFODNN7EXAMPLE',
       secret_access_key = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
-      format = 'CSV',
-      url = 'https://s3.us-east-1.amazonaws.com/yourbucket/mydata/';
+      format = 'CSV' NOT OVERRIDABLE,
+      url = 'https://s3.us-east-1.amazonaws.com/yourbucket/mydata/' OVERRIDABLE;
     CREATE DATABASE test_db;
     CREATE TABLE test_db.table_01 (
       key UInt32
@@ -20,7 +20,7 @@ Feature: Backup and restore functionality of named collections
     ENGINE=S3(test_s3_nc);
     """
 
-  @require_version_23.2
+  @require_version_24.3
   Scenario: from local to local storage
     When we create clickhouse01 clickhouse backup
     Then we got the following backups on clickhouse01


### PR DESCRIPTION
## Summary by Sourcery

Implement full backup of named collections by querying their JSON definitions, constructing CREATE NAMED COLLECTION statements, and uploading them directly via the storage loader.

New Features:
- Return named collections as a mapping from name to full CREATE NAMED COLLECTION DDL instead of just names.
- Add direct upload of named collections DDL data via the storage loader instead of using a local file.

Enhancements:
- Introduce a static helper to build named collection DDL from JSON definitions.
- Modify control logic to fetch both name and definition and map them to DDL queries.
- Update backup layout and orchestration to pass collection data through to the upload method.

Tests:
- Adjust integration tests to expect OVERRIDABLE clauses in the DDL and bump the required ClickHouse version to 24.3.