### PR TITLE
Fix Ci 

### DIFF
--- a/tests/integration/features/backup_replicated.feature
+++ b/tests/integration/features/backup_replicated.feature
@@ -982,6 +982,7 @@ Feature: Backup replicated merge tree table
       | replica-only         |  2  |
       | all-replicas         |  1  |
 
+  @require_version_23.3
   Scenario Outline: Clean metadata modes for replicated database
     Given ClickHouse settings
     """


### PR DESCRIPTION
Relicated databases cleanup is disabled for 22.8
https://github.com/yandex/ch-backup/blob/611bc8ea00d436b4f75bb94693d0a2a0e1155056/ch_backup/clickhouse/metadata_cleaner.py#L144-L147