### PR TITLE
Added ` NOT_DOWLOADED` state for parts.

### DIFF
--- a/ch_backup/backup/restore_context.py
+++ b/ch_backup/backup/restore_context.py
@@ -15,6 +15,7 @@ class PartState(str, Enum):
     """
     Represents status of the data part, during restore.
     """
+
     NOT_DOWNLOADED = "not_downloaded"
     INVALID = "invalid"
     DOWNLOADED = "downloaded"
@@ -116,7 +117,9 @@ class RestoreContext:
         with open(self._state_file, "r", encoding="utf-8") as f:
             state: Dict[str, Any] = json.load(f)
             databases: Dict[str, Dict[str, Dict[str, PartState]]] = defaultdict(
-                lambda: defaultdict(lambda: defaultdict(lambda: PartState.NOT_DOWNLOADED))
+                lambda: defaultdict(
+                    lambda: defaultdict(lambda: PartState.NOT_DOWNLOADED)
+                )
             )
             for db, tables in state.get("databases", {}).items():
                 for table, parts in tables.items():

--- a/ch_backup/backup/restore_context.py
+++ b/ch_backup/backup/restore_context.py
@@ -15,7 +15,7 @@ class PartState(str, Enum):
     """
     Represents status of the data part, during restore.
     """
-
+    NOT_DOWNLOADED = "not_downloaded"
     INVALID = "invalid"
     DOWNLOADED = "downloaded"
     RESTORED = "restored"
@@ -29,7 +29,7 @@ class RestoreContext:
     def __init__(self, config: Dict):
         self._state_file = config["restore_context_path"]
         self._databases_dict: Dict[str, Dict[str, Dict[str, PartState]]] = defaultdict(
-            lambda: defaultdict(lambda: defaultdict(lambda: PartState.INVALID))
+            lambda: defaultdict(lambda: defaultdict(lambda: PartState.NOT_DOWNLOADED))
         )
         self._failed: Mapping[str, Any] = defaultdict(
             lambda: defaultdict(
@@ -116,7 +116,7 @@ class RestoreContext:
         with open(self._state_file, "r", encoding="utf-8") as f:
             state: Dict[str, Any] = json.load(f)
             databases: Dict[str, Dict[str, Dict[str, PartState]]] = defaultdict(
-                lambda: defaultdict(lambda: defaultdict(lambda: PartState.INVALID))
+                lambda: defaultdict(lambda: defaultdict(lambda: PartState.NOT_DOWNLOADED))
             )
             for db, tables in state.get("databases", {}).items():
                 for table, parts in tables.items():


### PR DESCRIPTION
We have json with state of each part during restoring the backup and is's quite useful for big backups, helps to determine the current state of the restore(how many parts already restored, how many invalid parts and etc).  
But right now default value for the part state are `INVALID`.  So it is impossible to understand is part really `invalid` or it hasn't downloaded yet.