### PR TITLE
Pin Click framework version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ botocore<1.22; python_version <"3.12"
 psutil
 PyYAML<5.4
 PyNaCl==1.2.1
-click
+click>=8.0,<8.2
 cloup
 humanfriendly
 tabulate


### PR DESCRIPTION
### **User description**
ch-backup is not compatible with the recently releases click version 8.2.0.

The tests fail with the following error:
```
     And we restore clickhouse backup #0 to clickhouse01           # tests/integration/steps/ch_backup.py:97
      """
      override_replica_name: '{replica}'
      clean_zookeeper_mode: 'replica-only'
      replica_name: clickhouse01
      """
      Assertion Failed: execution failed with code 2, out: "Usage: ch-backup restore [OPTIONS] BACKUP
      Try 'ch-backup restore -h' for help.
      
      Error: Invalid value for '--clean-zookeeper-mode': 'replica-only' is not one of 'DISABLED', 'REPLICA_ONLY', 'ALL_REPLICAS'.
```
https://github.com/yandex/ch-backup/actions/runs/14972318277/job/42055996706


___

### **PR Type**
Bug fix


___

### **Description**
- Pin Click framework version to avoid compatibility issues


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements.txt</strong><dd><code>Pin Click framework version constraint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

requirements.txt

<li>Pinned Click framework version to >=8.0,<8.2 to prevent compatibility <br>issues with ch-backup<br> <li> Fixed issue where Click 8.2.0 caused test failures with <br>clean-zookeeper-mode parameter


</details>


  </td>
  <td><a href="https://github.com/yandex/ch-backup/pull/233/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>