### PR TITLE
Sourcery Test PR

### DIFF
--- a/images/clickhouse/Dockerfile
+++ b/images/clickhouse/Dockerfile
@@ -90,4 +90,5 @@ COPY staging/images/{{ instance_name }}/entrypoint.py /entrypoint.py
 
 EXPOSE 8123 8443 9000 9440
 
+USER clickhouse
 CMD ["python3", "/entrypoint.py"]

--- a/images/clickhouse/entrypoint.py
+++ b/images/clickhouse/entrypoint.py
@@ -12,4 +12,6 @@ if __name__ == "__main__":
     client.ensure_path("/{{ instance_name }}")
     client.stop()
 
-    subprocess.Popen(["supervisord", "-c", "/etc/supervisor/supervisord.conf"]).wait()
+    subprocess.Popen(
+        ["/usr/bin/clickhouse-server", "--config", "/etc/clickhouse-server/config.xml"]
+    ).wait()


### PR DESCRIPTION
## Summary by Sourcery

Replace supervisord with a direct clickhouse-server invocation in the entrypoint and switch the container user to clickhouse

Enhancements:
- Start ClickHouse server directly in the entrypoint instead of using supervisord
- Run the container process as the clickhouse user by default