### PR TITLE
Replace bandit linter with ruff linter security checks

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,8 +29,6 @@ jobs:
       run: make pylint
     - name: "lint: mypy"
       run: make mypy
-    - name: "lint: bandit"
-      run: make bandit
 
   test:
     name: test (Python ${{ matrix.python }}, ClickHouse ${{ matrix.clickhouse }})

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ all: lint test-unit build test-integration
 
 
 .PHONY: lint
-lint: setup isort black codespell ruff pylint mypy bandit
+lint: setup isort black codespell ruff pylint mypy
 
 
 .PHONY: isort
@@ -83,11 +83,6 @@ pylint: setup
 .PHONY: mypy
 mypy: setup
 	uv run mypy $(SRC_DIR) $(TESTS_DIR)
-
-
-.PHONY: bandit
-bandit: setup
-	uv run bandit -c bandit.yaml -r ch_backup
 
 
 .PHONY: format
@@ -204,7 +199,7 @@ help:
 	@echo "Targets:"
 	@echo "  build (default)            Build Python packages (sdist and wheel)."
 	@echo "  all                        Alias for \"lint test-unit build test-integration\"."
-	@echo "  lint                       Run all linter tools. Alias for \"isort black codespell ruff pylint mypy bandit\"."
+	@echo "  lint                       Run all linter tools. Alias for \"isort black codespell ruff pylint mypy\"."
 	@echo "  test-unit                  Run unit tests."
 	@echo "  test-integration           Run integration tests."
 	@echo "  isort                      Perform isort checks."
@@ -212,8 +207,7 @@ help:
 	@echo "  codespell                  Perform codespell checks."
 	@echo "  ruff                       Perform ruff checks."
 	@echo "  pylint                     Perform pylint checks."
-	@echo "  mypy                       Perform mypy checks.."
-	@echo "  bandit                     Perform bandit checks."
+	@echo "  mypy                       Perform mypy checks."
 	@echo "  create-test-env            Create test environment."
 	@echo "  start-test-env             Start test environment runtime."
 	@echo "  stop-test-env              Stop test environment runtime."

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Commands:
 
 ### Regression
 
-The regression test suite contains run of static code analysis tools (isort, black, ruff, pylint, mypy, bandit),
+The regression test suite contains run of static code analysis tools (isort, black, codespell, ruff, pylint, mypy),
 unit tests and integration tests.
 
 The tests can be run by issuing the command:
@@ -62,7 +62,7 @@ The following steps describe how to set up testing infrastructure on top of
 
 1. Create and run docker containers.
 ```
-$ make start-env
+$ make start-test-env
 ...
 Creating minio01.test_net_711 ...
 Creating clickhouse01.test_net_711 ...
@@ -100,7 +100,7 @@ Note: There are no prepopulated data in ClickHouse. So you need to insert some
 ### Testing new versions
 
 ```
-export CLICKHOUSE_VERSION=21.11.1.8636
+export CLICKHOUSE_VERSION=25.4.5.24
 make all
 ```
 

--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,6 +1,0 @@
-skips:
-  - B101  # assert_used
-  - B108  # hardcoded_tmp_directory
-  - B113  # request_without_timeout - overlap with pylint
-  - B404  # import_subprocess
-  - B603  # subprocess_without_shell_equals_true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "bandit >= 1.8.3",
     "behave >= 1.2.6",
     "black >= 25.1",
     "codespell >= 2.4.1",
@@ -74,7 +73,6 @@ dev = [
     "pylint >= 3.0, < 4.0",
     "pytest >= 8.3.5",
     "ruff >= 0.11.8",
-    "types-dataclasses >= 0.6.6",
     "types-pyyaml >= 6.0.12.20250402",
     "types-requests >= 2.31.0.6",
     "types-tabulate >= 0.9.0.20241207",
@@ -107,17 +105,24 @@ ignore-words-list = "sav,fpr"
 
 
 [tool.ruff]
-lint.select = ["E", "F", "W", "A"]
+lint.select = ["E", "F", "W", "A", "S"]
 lint.ignore = [
     "A003",  # "Class attribute is shadowing a Python builtin"
     "A005",  # Module `logging` shadows a Python standard-library module
     "E402",  # "Module level import not at top of file", duplicate corresponding pylint check
     "E501",  # "Line too long"
+    "S101",  # Use of `assert` detected
+    "S108",  # Probable insecure usage of temporary file or directory
+    "S110",  # `try`-`except`-`pass` detected, consider logging the exception"
+    "S113",  # Probable use of `requests` call without timeout
+    "S311",  # Standard pseudo-random generators are not suitable for cryptographic purposes
+    "S324",  # Probable use of insecure hash functions in `hashlib`: `md5`
+    "S602",  # `subprocess` call with `shell=True
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["F401"]  # "Unused import"
-
+"__init__.py" = ["F401"]  # Unused import
+"tests/**"    = ["S"]     # Disable security checks in tests
 
 [tool.pylint.main]
 py-version = "3.9"  # Minimum Python version to use for version dependent checks

--- a/uv.lock
+++ b/uv.lock
@@ -30,21 +30,6 @@ wheels = [
 ]
 
 [[package]]
-name = "bandit"
-version = "1.8.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "stevedore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/a5/144a45f8e67df9d66c3bc3f7e69a39537db8bff1189ab7cff4e9459215da/bandit-1.8.3.tar.gz", hash = "sha256:f5847beb654d309422985c36644649924e0ea4425c76dec2e89110b87506193a", size = 4232005, upload-time = "2025-02-17T05:24:57.031Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/85/db74b9233e0aa27ec96891045c5e920a64dd5cbccd50f8e64e9460f48d35/bandit-1.8.3-py3-none-any.whl", hash = "sha256:28f04dc0d258e1dd0f99dee8eefa13d1cb5e3fde1a5ab0c523971f97b289bcd8", size = 129078, upload-time = "2025-02-17T05:24:54.068Z" },
-]
-
-[[package]]
 name = "bcrypt"
 version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -332,7 +317,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "bandit" },
     { name = "behave" },
     { name = "black" },
     { name = "codespell" },
@@ -349,7 +333,6 @@ dev = [
     { name = "pylint" },
     { name = "pytest" },
     { name = "ruff" },
-    { name = "types-dataclasses" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
     { name = "types-tabulate" },
@@ -383,7 +366,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "bandit", specifier = ">=1.8.3" },
     { name = "behave", specifier = ">=1.2.6" },
     { name = "black", specifier = ">=25.1" },
     { name = "codespell", specifier = ">=2.4.1" },
@@ -400,7 +382,6 @@ dev = [
     { name = "pylint", specifier = ">=3.0,<4.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "ruff", specifier = ">=0.11.8" },
-    { name = "types-dataclasses", specifier = ">=0.6.6" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250402" },
     { name = "types-requests", specifier = ">=2.31.0.6" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
@@ -808,18 +789,6 @@ wheels = [
 ]
 
 [[package]]
-name = "markdown-it-py"
-version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
-]
-
-[[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -894,15 +863,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
-]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -1025,18 +985,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pbr"
-version = "6.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/01/d2/510cc0d218e753ba62a1bc1434651db3cd797a9716a0a66cc714cb4f0935/pbr-6.1.1.tar.gz", hash = "sha256:93ea72ce6989eb2eed99d0f75721474f69ad88128afdef5ac377eb797c4bf76b", size = 125702, upload-time = "2025-02-04T14:28:06.514Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/ac/684d71315abc7b1214d59304e23a982472967f6bf4bde5a98f1503f648dc/pbr-6.1.1-py2.py3-none-any.whl", hash = "sha256:38d4daea5d9fa63b3f626131b9d34947fd0c8be9b05a29276870580050a25a76", size = 108997, upload-time = "2025-02-04T14:28:03.168Z" },
-]
-
-[[package]]
 name = "platformdirs"
 version = "4.3.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1076,15 +1024,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736, upload-time = "2024-03-30T13:22:22.564Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552, upload-time = "2024-03-30T13:22:20.476Z" },
-]
-
-[[package]]
-name = "pygments"
-version = "2.19.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
 ]
 
 [[package]]
@@ -1287,20 +1226,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rich"
-version = "14.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.11.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1363,18 +1288,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
-]
-
-[[package]]
-name = "stevedore"
-version = "5.4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pbr" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/3f/13cacea96900bbd31bb05c6b74135f85d15564fc583802be56976c940470/stevedore-5.4.1.tar.gz", hash = "sha256:3135b5ae50fe12816ef291baff420acb727fcd356106e3e9cbfa9e5985cd6f4b", size = 513858, upload-time = "2025-02-20T14:03:57.285Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/45/8c4ebc0c460e6ec38e62ab245ad3c7fc10b210116cea7c16d61602aa9558/stevedore-5.4.1-py3-none-any.whl", hash = "sha256:d10a31c7b86cba16c1f6e8d15416955fc797052351a56af15e608ad20811fcfe", size = 49533, upload-time = "2025-02-20T14:03:55.849Z" },
 ]
 
 [[package]]
@@ -1456,15 +1369,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b1/09/a439bec5888f00a54b8b9f05fa94d7f901d6735ef4e55dcec9bc37b5d8fa/tomlkit-0.13.2.tar.gz", hash = "sha256:fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79", size = 192885, upload-time = "2024-08-14T08:19:41.488Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl", hash = "sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde", size = 37955, upload-time = "2024-08-14T08:19:40.05Z" },
-]
-
-[[package]]
-name = "types-dataclasses"
-version = "0.6.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4b/6a/dec8fbc818b1e716cb2d9424f1ea0f6f3b1443460eb6a70d00d9d8527360/types-dataclasses-0.6.6.tar.gz", hash = "sha256:4b5a2fcf8e568d5a1974cd69010e320e1af8251177ec968de7b9bb49aa49f7b9", size = 2884, upload-time = "2022-06-30T09:49:21.449Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/85/23ab2bbc280266af5bf22ded4e070946d1694d1721ced90666b649eaa795/types_dataclasses-0.6.6-py3-none-any.whl", hash = "sha256:a0a1ab5324ba30363a15c9daa0f053ae4fff914812a1ebd8ad84a08e5349574d", size = 2868, upload-time = "2022-06-30T09:49:19.977Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Replace Bandit with Ruff for security linting by removing Bandit config and targets, enabling Ruff security rules, and updating scripts, docs, and CI accordingly.

Enhancements:
- Consolidate security linting under Ruff by enabling security rule category “S” and adding specific checks (S101, S108, S110, S113, S311, S324, S602)
- Remove Bandit from development dependencies, Makefile targets, and project configuration
- Add per-file ignores to disable Ruff security checks in test files

CI:
- Remove Bandit lint step from GitHub Actions workflow

Documentation:
- Update README and Makefile help text to remove Bandit references and rename `start-env` to `start-test-env`
- Bump default ClickHouse version in README