### PR TITLE
Fix step order in create test environment

### DIFF
--- a/tests/integration/env_control.py
+++ b/tests/integration/env_control.py
@@ -14,8 +14,8 @@ from tests.integration.modules import compose, docker, minio, templates
 SESSION_STATE_CONF = ".session_conf.sav"
 STAGES = {
     "create": [
-        compose.create_config,
         templates.render_docker_configs,
+        compose.create_config,
         compose.build_images,
     ],
     "start": [


### PR DESCRIPTION
**without fix** 
```
# make clean
# make start-test-env
...
Creating zookeeper01.test_net_2074    ... done
Creating minio01.test_net_2074        ... done
Creating broken-proxy01.test_net_2074 ... done
Creating proxy01.test_net_2074        ... done
Creating proxy-api01.test_net_2074    ... done
Creating clickhouse01.test_net_2074   ... done
Creating clickhouse02.test_net_2074   ... done

# docker ps
CONTAINER ID   IMAGE                          COMMAND                  CREATED              STATUS                          PORTS                                                                                                                    NAMES
995978e43f46   proxy-api01:test_net_2074      "python3 /app.py"        About a minute ago   Up About a minute               0.0.0.0:34716->8080/tcp, :::34703->8080/tcp                                                                              proxy-api01.test_net_2074
0ab62fa95f8a   proxy01:test_net_2074          "tinyproxy -d -c /ti…"   About a minute ago   Up About a minute               0.0.0.0:34714->4080/tcp, :::34701->4080/tcp                                                                              proxy01.test_net_2074
a4e5df561ed5   minio01:test_net_2074          "/usr/bin/docker-ent…"   About a minute ago   Up About a minute (unhealthy)   0.0.0.0:34715->9000/tcp, :::34702->9000/tcp                                                                              minio01.test_net_2074
de009ff73405   broken-proxy01:test_net_2074   "python3 /app.py"        About a minute ago   Up About a minute               0.0.0.0:34713->4080/tcp, :::34700->4080/tcp                                                                              broken-proxy01.test_net_2074
c96a9d1c7fb6   zookeeper01:test_net_2074      "/docker-entrypoint.…"   About a minute ago   Up About a minute               2888/tcp, 3888/tcp, 8080/tcp, 0.0.0.0:34718->2181/tcp, :::34705->2181/tcp, 0.0.0.0:34717->2281/tcp, :::34704->2281/tcp   zookeeper01.test_net_2074

# docker logs clickhouse01.test_net_2074
Connection dropped: socket connection error: Connection refused
Connection dropped: socket connection error: Connection refused
Connection dropped: socket connection error: Connection refused
Connection dropped: socket connection error: Connection refused
Error: could not find config file /etc/supervisor/supervisord.conf
For help, use /usr/bin/supervisord -h
```

**with fix**
```
# make clean
# make start-test-env
...
Creating proxy-api01.test_net_3602    ... done
Creating zookeeper01.test_net_3602    ... done
Creating broken-proxy01.test_net_3602 ... done
Creating minio01.test_net_3602        ... done
Creating proxy01.test_net_3602        ... done
Creating clickhouse01.test_net_3602   ... done
Creating clickhouse02.test_net_3602   ... done

# docker ps
CONTAINER ID   IMAGE                          COMMAND                  CREATED         STATUS                     PORTS                                                                                                                                                   NAMES
2671b3c97485   clickhouse01:test_net_3602     "python3 /entrypoint…"   5 minutes ago   Up 4 minutes               8443/tcp, 9440/tcp, 0.0.0.0:34734->22/tcp, :::34721->22/tcp, 0.0.0.0:34732->8123/tcp, :::34719->8123/tcp, 0.0.0.0:34731->9000/tcp, :::34718->9000/tcp   clickhouse01.test_net_3602
deb3e7f8c91b   clickhouse02:test_net_3602     "python3 /entrypoint…"   5 minutes ago   Up 4 minutes               8443/tcp, 9440/tcp, 0.0.0.0:34736->22/tcp, :::34723->22/tcp, 0.0.0.0:34735->8123/tcp, :::34722->8123/tcp, 0.0.0.0:34733->9000/tcp, :::34720->9000/tcp   clickhouse02.test_net_3602
9ba2af5e5422   proxy01:test_net_3602          "tinyproxy -d -c /ti…"   5 minutes ago   Up 5 minutes               0.0.0.0:34726->4080/tcp, :::34713->4080/tcp                                                                                                             proxy01.test_net_3602
c7d5c17a2cd9   broken-proxy01:test_net_3602   "python3 /app.py"        5 minutes ago   Up 5 minutes               0.0.0.0:34728->4080/tcp, :::34715->4080/tcp                                                                                                             broken-proxy01.test_net_3602
956bbce52666   minio01:test_net_3602          "/usr/bin/docker-ent…"   5 minutes ago   Up 5 minutes (unhealthy)   0.0.0.0:34727->9000/tcp, :::34714->9000/tcp                                                                                                             minio01.test_net_3602
7a9bf19a458a   zookeeper01:test_net_3602      "/docker-entrypoint.…"   5 minutes ago   Up 5 minutes               2888/tcp, 3888/tcp, 8080/tcp, 0.0.0.0:34730->2181/tcp, :::34717->2181/tcp, 0.0.0.0:34729->2281/tcp, :::34716->2281/tcp                                  zookeeper01.test_net_3602
dba9684e720b   proxy-api01:test_net_3602      "python3 /app.py"        5 minutes ago   Up 5 minutes               0.0.0.0:34725->8080/tcp, :::34712->8080/tcp                                                                                                             proxy-api01.test_net_3602

# docker exec -it clickhouse01.test_net_3602 clickhouse-client
ClickHouse client version 25.4.5.24 (official build).
Connecting to localhost:9000 as user default.
Connected to ClickHouse server version 25.4.5.

clickhouse01.test_net_3602 :)
```

## Summary by Sourcery

Bug Fixes:
- Swap the order of templates.render_docker_configs and compose.create_config in the create stage to generate configuration files before building test environment images