### PR TITLE
Fix false negatves in compare_schema function

### DIFF
--- a/ch_backup/util.py
+++ b/ch_backup/util.py
@@ -347,8 +347,6 @@ def compare_schema(schema_a: str, schema_b: str) -> bool:
         )
 
         # Force quotas for Distributed engine parameters to unify syntax across ClickHouse versions
-        # `... ENGINE = Distributed('aaa', bbb, ccc, xxx) ...` - in versions lower 20.1
-        # `... ENGINE = Distributed('aaa', 'bbb', 'ccc', xxx) ...` - in versions 20.1 and higher
         result = re.sub(
             r"engine = distributed\('([^']+)', ('?)(\w+)\2, ('?)(\w+)\4(, .*)?\)",
             r"engine = distributed('\1', '\3', '\5'\6)",


### PR DESCRIPTION
## Summary by Sourcery

Enhance schema comparison to normalize and unify SQL syntax variations and expand test coverage

Enhancements:
- Strip and collapse whitespace and standardize casing during schema normalization
- Unify ATTACH and CREATE statements and enforce backtick quoting for identifiers while dropping optional UUID clauses
- Standardize Distributed engine syntax by enforcing quoted parameters across ClickHouse versions

Tests:
- Replace legacy TestNormalizeSchema with a parameterized test_compare_schema covering diverse table and view statement variations to catch false negatives