### PR TITLE
Fix integration tests

### DIFF
--- a/ch_backup/__init__.py
+++ b/ch_backup/__init__.py
@@ -2,5 +2,11 @@
 ClickHouse backup tool.
 """
 
+import warnings
+
+# Ignore warnings from dependencies (stopit) on usage of deprecated pkg_resources
+# https://setuptools.pypa.io/en/latest/pkg_resources.html#api-reference
+warnings.filterwarnings("ignore", message="pkg_resources is deprecated as an API")
+
 from .cli import cli as main
 from .version import __version__

--- a/ch_backup/version.py
+++ b/ch_backup/version.py
@@ -2,9 +2,9 @@
 Version module.
 """
 
-from pkg_resources import resource_string
+from importlib import resources
 
-__version__ = resource_string(__name__, "version.txt").decode().strip()
+__version__ = resources.files("ch_backup").joinpath("version.txt").read_text().strip()
 
 
 def get_version() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,10 @@ dependencies = [
     "pypeln >= 0.4.9",
     "pyyaml >= 5.4",
     "requests >= 2.20",
-    "setuptools >= 71.1",  # for pkg_resources module
     "tabulate >= 0.9",
     "tenacity >= 8.3",
     "xmltodict >= 0.14",
+    "setuptools >= 71, < 81",  # for the library "stopit" (dependency of "pypeln")
 ]
 
 [dependency-groups]
@@ -136,6 +136,7 @@ disable = [
     "too-few-public-methods",
     "unnecessary-pass",
     "use-dict-literal",
+    "wrong-import-position",
 ]
 
 [tool.pylint.basic]

--- a/uv.lock
+++ b/uv.lock
@@ -247,7 +247,7 @@ requires-dist = [
     { name = "pypeln", specifier = ">=0.4.9" },
     { name = "pyyaml", specifier = ">=5.4" },
     { name = "requests", specifier = ">=2.20" },
-    { name = "setuptools", specifier = ">=71.1" },
+    { name = "setuptools", specifier = ">=71,<81" },
     { name = "tabulate", specifier = ">=0.9" },
     { name = "tenacity", specifier = ">=8.3" },
     { name = "xmltodict", specifier = ">=0.14" },
@@ -454,16 +454,16 @@ wheels = [
 
 [[package]]
 name = "hypothesis"
-version = "6.131.27"
+version = "6.131.28"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/9e/81147d07d4a4f9ed3ed92e9ec2bc4244e15d95204819fef80d5e7166eb26/hypothesis-6.131.27.tar.gz", hash = "sha256:9bd7e7e7bdbfc1b6e1f152dafacd398334588a374618490415209eeb26110b8d", size = 440336, upload-time = "2025-05-24T22:36:10.913Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/3b/4f87f1c3e19bd66f60259c55deb0cc0e05d84556d7bbc0a905c391b47d75/hypothesis-6.131.28.tar.gz", hash = "sha256:8294567dd46c21049deb095881ce76e7766e31468c5fb93a37f13431c9b38ad1", size = 441837, upload-time = "2025-05-25T17:58:35.024Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/68/45f9c1acba9100068299b51ee6204fabb43c2fa6d537071638039a2b4122/hypothesis-6.131.27-py3-none-any.whl", hash = "sha256:5edac0fa73e38f123f93b739626c59b1ead7aedfd329c893e04cb0a6c1ab27af", size = 504920, upload-time = "2025-05-24T22:36:07.337Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/f4/cc00d61c6eee87490453a39bb47999ee0bab7a5ff5bd246f0d16b86c7f63/hypothesis-6.131.28-py3-none-any.whl", hash = "sha256:8f34eb2789d8cb47f4b82f67832cf99596fb2a9919a2753b7aba11458f71edb2", size = 506437, upload-time = "2025-05-25T17:58:31.301Z" },
 ]
 
 [[package]]
@@ -987,11 +987,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "80.8.0"
+version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8d/d2/ec1acaaff45caed5c2dedb33b67055ba9d4e96b091094df90762e60135fe/setuptools-80.8.0.tar.gz", hash = "sha256:49f7af965996f26d43c8ae34539c8d99c5042fbff34302ea151eaa9c207cd257", size = 1319720, upload-time = "2025-05-20T14:02:53.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/29/93c53c098d301132196c3238c312825324740851d77a8500a2462c0fd888/setuptools-80.8.0-py3-none-any.whl", hash = "sha256:95a60484590d24103af13b686121328cc2736bee85de8936383111e421b9edc0", size = 1201470, upload-time = "2025-05-20T14:02:51.348Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fix for the following integration tests error:

```
  Scenario: from local to local storage                                                       # tests/integration/features/access_control_backup.feature:24
    Given default configuration                                                               # tests/integration/steps/common.py:14
    And a working s3                                                                          # tests/integration/steps/s3.py:13
    And a working zookeeper on zookeeper01                                                    # tests/integration/steps/zookeeper.py:18
    And a working clickhouse on clickhouse01                                                  # tests/integration/steps/clickhouse.py:17
    And a working clickhouse on clickhouse02                                                  # tests/integration/steps/clickhouse.py:17
    And we have executed queries on clickhouse01                                              # tests/integration/steps/clickhouse.py:120
      """
      CREATE DATABASE test_db;
      CREATE TABLE test_db.table_01 (
          EventDate DateTime,
          CounterID UInt32,
          UserID UInt32
      )
      ENGINE = ReplicatedMergeTree('/clickhouse/tables/shard_01/test_db.table_01', 'static_name')
      PARTITION BY toYYYYMM(EventDate)
      ORDER BY (CounterID, EventDate, intHash32(UserID))
      SAMPLE BY intHash32(UserID);
      INSERT INTO test_db.table_01 SELECT now(), number, rand() FROM system.numbers LIMIT 1000
      """
    Given we have executed queries on clickhouse01                                            # tests/integration/steps/clickhouse.py:120
      """
      CREATE USER test_user IDENTIFIED WITH plaintext_password BY 'password';
      CREATE ROLE test_role;
      GRANT SELECT ON test_db.* TO test_role;
      CREATE ROW POLICY filter ON test_db.table_01 FOR SELECT USING CounterID < 5 TO test_role;
      CREATE ROW POLICY filter2 ON test_db.table_01 FOR SELECT USING CounterID > 2 TO test_role, test_user;
      CREATE QUOTA test_quota FOR INTERVAL 1 DAY MAX QUERIES 10 TO test_role;
      CREATE SETTINGS PROFILE memory_profile SETTINGS max_memory_usage = 100000001 MIN 90000000 MAX 110000000 TO test_role;
      """
    When we create clickhouse01 clickhouse backup                                             # tests/integration/steps/ch_backup.py:29
    Then we got the following backups on clickhouse01                                         # tests/integration/steps/ch_backup.py:168
      | num | state   | data_count | link_count |
      | 0   | created | 1          | 0          |
      Assertion Failed: Backup count = 3, expected 1
      Expected: <1>
           but: was <3>
```

```
root@clickhouse01:/# ch-backup list
/usr/local/lib/python3.10/site-packages/stopit/__init__.py:10: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
35c09141-1de6-4dce-979f-f6c6e3141af4
```


## Summary by Sourcery

Switch to importlib.resources for version file reading, remove the setuptools dependency, and update lint configuration

Enhancements:
- Use importlib.resources.files to load version.txt instead of pkg_resources
- Remove setuptools requirement to avoid the deprecated pkg_resources API
- Disable the "wrong-import-position" lint rule in the project configuration