### PR TITLE
Support of overriding ClickHouse query-level settings through config

### DIFF
--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -477,42 +477,44 @@ class ClickhouseCTL:
         self._ch_client = ClickhouseClient(self._ch_ctl_config)
         self._ch_version = self._ch_client.query(GET_VERSION_SQL)
         self._disks = self.get_disks()
-        settings = {
-            "allow_deprecated_database_ordinary": 1,
-            "allow_deprecated_syntax_for_merge_tree": 1,
-            "allow_experimental_database_materialized_postgresql": 1,
-            "allow_experimental_database_materialized_mysql": 1,
-            "allow_experimental_database_replicated": 1,
-            "allow_experimental_funnel_functions": 1,
-            "allow_experimental_hash_functions": 1,
-            "allow_experimental_live_view": 1,
-            "allow_experimental_window_view": 1,
-            "allow_experimental_object_type": 1,
-            "allow_suspicious_codecs": 1,
-            "allow_suspicious_low_cardinality_types": 1,
-            "check_table_dependencies": 0,
-            "kafka_disable_num_consumers_limit": 1,
-        }
-        if self.ch_version_ge("22.9"):
-            settings.update(
-                {
-                    "allow_experimental_annoy_index": 1,
-                    "allow_suspicious_fixed_string_types": 1,
-                }
-            )
-        if self.ch_version_ge("23.1"):
-            settings.update(
-                {
-                    "allow_experimental_inverted_index": 1,
-                }
-            )
-        if self.ch_version_ge("23.12"):
-            settings.update(
-                {
-                    "allow_experimental_refreshable_materialized_view": 1,
-                    "allow_suspicious_ttl_expressions": 1,
-                }
-            )
+        settings = self._ch_ctl_config.get("settings")
+        if settings is None:
+            settings = {
+                "allow_deprecated_database_ordinary": 1,
+                "allow_deprecated_syntax_for_merge_tree": 1,
+                "allow_experimental_database_materialized_postgresql": 1,
+                "allow_experimental_database_materialized_mysql": 1,
+                "allow_experimental_database_replicated": 1,
+                "allow_experimental_funnel_functions": 1,
+                "allow_experimental_hash_functions": 1,
+                "allow_experimental_live_view": 1,
+                "allow_experimental_window_view": 1,
+                "allow_experimental_object_type": 1,
+                "allow_suspicious_codecs": 1,
+                "allow_suspicious_low_cardinality_types": 1,
+                "check_table_dependencies": 0,
+                "kafka_disable_num_consumers_limit": 1,
+            }
+            if self.ch_version_ge("22.9"):
+                settings.update(
+                    {
+                        "allow_experimental_annoy_index": 1,
+                        "allow_suspicious_fixed_string_types": 1,
+                    }
+                )
+            if self.ch_version_ge("23.1"):
+                settings.update(
+                    {
+                        "allow_experimental_inverted_index": 1,
+                    }
+                )
+            if self.ch_version_ge("23.12"):
+                settings.update(
+                    {
+                        "allow_experimental_refreshable_materialized_view": 1,
+                        "allow_suspicious_ttl_expressions": 1,
+                    }
+                )
         self._ch_client.settings.update(settings)
 
     def chown_detached_table_parts(self, table: Table, context: RestoreContext) -> None:

--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -496,25 +496,13 @@ class ClickhouseCTL:
                 "kafka_disable_num_consumers_limit": 1,
             }
             if self.ch_version_ge("22.9"):
-                settings.update(
-                    {
-                        "allow_experimental_annoy_index": 1,
-                        "allow_suspicious_fixed_string_types": 1,
-                    }
-                )
+                settings["allow_experimental_annoy_index"] = 1
+                settings["allow_suspicious_fixed_string_types"] = 1
             if self.ch_version_ge("23.1"):
-                settings.update(
-                    {
-                        "allow_experimental_inverted_index": 1,
-                    }
-                )
+                settings["allow_experimental_inverted_index"] = 1
             if self.ch_version_ge("23.12"):
-                settings.update(
-                    {
-                        "allow_experimental_refreshable_materialized_view": 1,
-                        "allow_suspicious_ttl_expressions": 1,
-                    }
-                )
+                settings["allow_experimental_refreshable_materialized_view"] = 1
+                settings["allow_suspicious_ttl_expressions"] = 1
         self._ch_client.settings.update(settings)
 
     def chown_detached_table_parts(self, table: Table, context: RestoreContext) -> None:

--- a/images/clickhouse/config/users.xml
+++ b/images/clickhouse/config/users.xml
@@ -8,7 +8,6 @@
             <password></password>
             <access_management>1</access_management>
             <profile>default</profile>
-            <quota>default</quota>
 {% if ch_version_ge('23.2') %}
             <show_named_collections>1</show_named_collections>
             <show_named_collections_secrets>1</show_named_collections_secrets>
@@ -21,16 +20,4 @@
     <profiles>
         <default/>
     </profiles>
-    <quotas>
-        <default>
-            <interval>
-                <duration>3600</duration>
-                <queries>0</queries>
-                <errors>0</errors>
-                <result_rows>0</result_rows>
-                <read_rows>0</read_rows>
-                <execution_time>0</execution_time>
-            </interval>
-        </default>
-    </quotas>
 </yandex>


### PR DESCRIPTION
## Summary by Sourcery

Enable custom ClickHouse query-level settings via configuration with a fallback to existing defaults and clean up legacy quota entries in the ClickHouse user config.

New Features:
- Allow overriding ClickHouse client query-level settings through the backup configuration.

Enhancements:
- Retain previous hard-coded settings as a default when no custom settings are provided.

Chores:
- Remove the default <quota> entry and the entire <quotas> section from the ClickHouse users.xml template.