### PR TITLE
Drop table if UUID is equal but schemas mismatch during restore

### DIFF
--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -123,6 +123,7 @@ GET_TABLES_SHORT_SQL = strip_query(
     SELECT
         database,
         name,
+        uuid,
         engine,
         create_table_query
     FROM system.tables

--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -580,11 +580,7 @@ class TableBackup(BackupManager):
             elif existing_table := (
                 existing_tables_by_uuid.get(table.uuid) if table.uuid else None
             ):
-                if compare_schema(
-                    existing_table.create_statement, table.create_statement
-                ):
-                    # Skip table
-                    continue
+                # Schemas mismatch here at least in name
                 logging.warning(
                     'Table "{}"."{}" will be dropped as its UUID is equal but schema mismatches the schema from backup: "{}" != "{}"',
                     existing_table.database,

--- a/tests/integration/features/backup_restore.feature
+++ b/tests/integration/features/backup_restore.feature
@@ -253,7 +253,7 @@ Feature: Backup & Restore
     1
     """
 
-  Scenario: Overwrite existing table on destination node when schema is mismatched
+  Scenario: Overwrite existing table on destination node when name is equal and schema is mismatched
     When we drop all databases at clickhouse01
     And we drop all databases at clickhouse02    
     And we execute queries on clickhouse01
@@ -272,6 +272,39 @@ Feature: Backup & Restore
     ENGINE MergeTree PARTITION BY partition_id ORDER BY (partition_id, a, b);
 
     INSERT INTO test_db.test_table SELECT number % 2, number, number FROM system.numbers LIMIT 100;
+    """
+    And we put following info in "/etc/clickhouse-server/conf.d/max_table_size_to_drop.xml" at clickhouse02
+    """
+    <yandex>
+      <max_table_size_to_drop>1</max_table_size_to_drop>
+    </yandex>
+    """
+    And we execute query on clickhouse02
+    """
+    SYSTEM RELOAD CONFIG
+    """
+    And we restore clickhouse backup #0 to clickhouse02
+    Then clickhouse02 has same schema as clickhouse01
+
+  Scenario: Overwrite existing table on destination node when UUID is equal and schema is mismatched
+    When we drop all databases at clickhouse01
+    And we drop all databases at clickhouse02    
+    And we execute queries on clickhouse01
+    """
+    CREATE DATABASE test_db;
+    ATTACH TABLE test_db.test_table UUID '3a00aeb8-2605-4eec-8215-777777777777' (partition_id Int32, a Int32)
+    ENGINE MergeTree PARTITION BY partition_id ORDER BY (partition_id, a);
+
+    INSERT INTO test_db.test_table SELECT number % 2, number FROM system.numbers LIMIT 100;
+    """
+    And we create clickhouse01 clickhouse backup  
+    And we execute queries on clickhouse02
+    """
+    CREATE DATABASE test_db;
+    ATTACH TABLE test_db.other_test_table UUID '3a00aeb8-2605-4eec-8215-777777777777' (partition_id Int32, a Int32, b Int32)
+    ENGINE MergeTree PARTITION BY partition_id ORDER BY (partition_id, a, b);
+
+    INSERT INTO test_db.other_test_table SELECT number % 2, number, number FROM system.numbers LIMIT 100;
     """
     And we put following info in "/etc/clickhouse-server/conf.d/max_table_size_to_drop.xml" at clickhouse02
     """

--- a/tests/integration/features/backup_restore.feature
+++ b/tests/integration/features/backup_restore.feature
@@ -253,7 +253,7 @@ Feature: Backup & Restore
     1
     """
 
-  Scenario: Overwrite existing table on destination node when name is equal and schema is mismatched
+  Scenario: Overwrite existing table on destination node when name is equal and schema is mismatched with checking force_drop_table
     When we drop all databases at clickhouse01
     And we drop all databases at clickhouse02    
     And we execute queries on clickhouse01
@@ -284,6 +284,11 @@ Feature: Backup & Restore
     SYSTEM RELOAD CONFIG
     """
     And we restore clickhouse backup #0 to clickhouse02
+    And we delete the following file at "/etc/clickhouse-server/conf.d/max_table_size_to_drop.xml" on clickhouse02
+    And we execute query on clickhouse02
+    """
+    SYSTEM RELOAD CONFIG
+    """
     Then clickhouse02 has same schema as clickhouse01
 
   Scenario: Overwrite existing table on destination node when UUID is equal and schema is mismatched
@@ -305,16 +310,6 @@ Feature: Backup & Restore
     ENGINE MergeTree PARTITION BY partition_id ORDER BY (partition_id, a, b);
 
     INSERT INTO test_db.other_test_table SELECT number % 2, number, number FROM system.numbers LIMIT 100;
-    """
-    And we put following info in "/etc/clickhouse-server/conf.d/max_table_size_to_drop.xml" at clickhouse02
-    """
-    <yandex>
-      <max_table_size_to_drop>1</max_table_size_to_drop>
-    </yandex>
-    """
-    And we execute query on clickhouse02
-    """
-    SYSTEM RELOAD CONFIG
     """
     And we restore clickhouse backup #0 to clickhouse02
     Then clickhouse02 has same schema as clickhouse01

--- a/tests/integration/steps/clickhouse.py
+++ b/tests/integration/steps/clickhouse.py
@@ -73,6 +73,12 @@ def step_put_file(context, path, node):
     put_file(container, bytes(context.text, "utf-8"), path)
 
 
+@when('we delete the following file at "{path}" on {node:w}')
+def step_delete_file(context, path, node):
+    container = get_container(context, node)
+    assert container.exec_run(f"rm -rf {path}").exit_code == 0
+
+
 @given("{node:w} has test clickhouse data {test_name:w}")
 @when("{node:w} has test clickhouse data {test_name:w}")
 def step_fill_with_test_data(context, node, test_name):


### PR DESCRIPTION
Fix an error during restore. This can take place when we do retry of restoring with different backup and after the first try table was renamed.
```
2025-06-17 12:40:32,508 MainProcess 54616 [DEBUG   ] ch-backup: Executing query: ATTACH TABLE `default`.`test_table` UUID '3a00aeb8-2605-4eec-8215-08c0ecb51112'
(
    `column1` UInt32,
    `column2` DateTime
)
ENGINE = MergeTree
PARTITION BY column1 % 2000
ORDER BY (column1, column2)
SETTINGS index_granularity = 8192

2025-06-17 12:40:32,516 MainProcess 54616 [DEBUG   ] ch-backup: Failed to restore table `default`.`test_table`. Removing it. Exception: Code: 57. DB::Exception: Mapping for table with UUID=3a00aeb8-2605-4eec-8215-08c0ecb51112 already exists. It happened due to UUID collision, most likely because some not random UUIDs were manually specified in CREATE queries. (TABLE_ALREADY_EXISTS) (version 25.3.3.42 (official build))
2025-06-17 12:40:32,516 MainProcess 54616 [DEBUG   ] ch-backup: Executing query: DROP TABLE IF EXISTS `default`.`test_table` NO DELAY
2025-06-17 12:40:32,518 MainProcess 54616 [DEBUG   ] ch-backup: Errors 2, unprocessed 1
2025-06-17 12:40:32,518 MainProcess 54616 [ERROR   ] ch-backup: Failed to restore "default"."test_table" with "ClickhouseBackupError('Failed to restore table: default.test_table')", no retries anymore
```

## Summary by Sourcery

Refine the restore preprocessing to handle both name‐ and UUID‐based schema collisions by dropping any existing tables whose schema diverges from the backup, preventing errors during retry restores.

Bug Fixes:
- Fix restore failure caused by UUID collisions when an existing table’s schema mismatches the backup by dropping the conflicting table before retry.

Enhancements:
- Track existing tables by both database/name and UUID to detect schema mismatches more precisely.
- Skip restoring tables whose schema already matches by either name or UUID.
- Update drop logic to target the actual existing table instance.
- Expose table UUID in the system.tables query for accurate detection.

Tests:
- Add an integration scenario to verify overwrite behavior when UUID matches but schema mismatches.
- Rename the existing scenario to clarify name‐based schema mismatch behavior.