### PR TITLE
Wait for async download_cloud_storage_metadata

### DIFF
--- a/ch_backup/ch_backup.py
+++ b/ch_backup/ch_backup.py
@@ -446,6 +446,8 @@ class ClickhouseBackup:
         self._context.backup_layout.download_cloud_storage_metadata(
             backup_meta, source_disk, disk_name
         )
+        self._context.backup_layout.wait()
+
         return True
 
     def _delete(


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Invoke wait() on the backup layout to ensure cloud storage metadata download finishes before proceeding