### PR TITLE
Handle 25.8

### DIFF
--- a/tests/integration/features/cloud_storage.feature
+++ b/tests/integration/features/cloud_storage.feature
@@ -157,7 +157,6 @@ Feature: Backup & Clean & Restore
     []
     """
 
-  @require_version_23.7
   Scenario Outline: All backup data is deleted including data of removed tables
     Given ch-backup configuration on clickhouse01
     """
@@ -203,6 +202,7 @@ Feature: Backup & Clean & Restore
     """
     []
     """
+    @require_version_23.7
     @require_version_less_than_25.8
     Examples:
     | object_count |

--- a/tests/integration/features/cloud_storage.feature
+++ b/tests/integration/features/cloud_storage.feature
@@ -158,7 +158,7 @@ Feature: Backup & Clean & Restore
     """
 
   @require_version_23.7
-  Scenario: All backup data is deleted including data of removed tables
+  Scenario Outline: All backup data is deleted including data of removed tables
     Given ch-backup configuration on clickhouse01
     """
     backup:
@@ -185,7 +185,7 @@ Feature: Backup & Clean & Restore
       | num | state   | data_count | link_count | title   |
       | 0   | created | 5          | 0          | deleted |
     And s3 contains 15 objects
-    And s3 bucket cloud-storage-01 contains 10 objects
+    And s3 bucket cloud-storage-01 contains <object_count> objects
     And we got the following s3 backup directories on clickhouse01
     """
     ["12345678T123456"]
@@ -203,3 +203,12 @@ Feature: Backup & Clean & Restore
     """
     []
     """
+    @require_version_less_than_25.8
+    Examples:
+    | object_count |
+    | 10           |
+
+    @require_version_25.8
+    Examples:
+    | object_count |
+    | 11           |


### PR DESCRIPTION
## Summary by Sourcery

Parameterize the backup cleanup scenario with a Scenario Outline and version-based Examples to adjust expected S3 object counts for ClickHouse versions before and after 25.8

Tests:
- Convert a static scenario into a Scenario Outline with an <object_count> placeholder
- Add version-specific Examples tables to expect 10 objects for versions less than 25.8 and 11 objects for version 25.8 and above