### PR TITLE
[fix] Use dynamic backup path from config instead of stored path from metadata

### DIFF
--- a/ch_backup/backup/deduplication.py
+++ b/ch_backup/backup/deduplication.py
@@ -25,7 +25,7 @@ class PartDedupInfo(Slotted):
         "database",
         "table",
         "name",
-        "backup_path",
+        "backup_name",
         "checksum",
         "size",
         "files",
@@ -41,7 +41,7 @@ class PartDedupInfo(Slotted):
         database: str,
         table: str,
         name: str,
-        backup_path: str,
+        backup_name: str,
         checksum: str,
         size: int,
         files: Sequence[str],
@@ -53,7 +53,7 @@ class PartDedupInfo(Slotted):
         self.database = database
         self.table = table
         self.name = name
-        self.backup_path = backup_path
+        self.backup_name = backup_name
         self.checksum = checksum
         self.size = size
         self.files = files
@@ -67,7 +67,7 @@ class PartDedupInfo(Slotted):
         Convert to string to use it in insert query
         """
         files_array = "[" + ",".join(f"'{file}'" for file in self.files) + "]"
-        return f"('{self.database}','{self.table}','{self.name}','{self.backup_path}','{self.checksum}',{self.size},{files_array},{int(self.tarball)},'{self.disk_name}',{int(self.verified)}, {int(self.encrypted)})"
+        return f"('{self.database}','{self.table}','{self.name}','{self.backup_name}','{self.checksum}',{self.size},{files_array},{int(self.tarball)},'{self.disk_name}',{int(self.verified)}, {int(self.encrypted)})"
 
 
 TableDedupReferences = Set[str]
@@ -148,7 +148,7 @@ def _populate_dedup_info(
     dedup_batch_size = context.config["deduplication_batch_size"]
 
     databases_to_handle = {db.name: _DatabaseToHandle(db.name) for db in databases}
-    dedup_backup_paths = set(backup.path for backup in dedup_backups_with_light_meta)
+    dedup_backup_names = {backup.name for backup in dedup_backups_with_light_meta}
     for backup in dedup_backups_with_light_meta:
         backup = layout.reload_backup(backup, use_light_meta=False)
 
@@ -190,18 +190,18 @@ def _populate_dedup_info(
 
                     if part.link:
                         verified = True
-                        backup_path = part.link
-                        if backup_path not in dedup_backup_paths:
+                        backup_name = part.link
+                        if backup_name not in dedup_backup_names:
                             continue
                     else:
                         verified = False
-                        backup_path = backup.path
+                        backup_name = backup.name
 
                     part_dedup = PartDedupInfo(
                         database=db.name,
                         table=table.name,
                         name=part.name,
-                        backup_path=backup_path,
+                        backup_name=backup_name,
                         checksum=part.checksum,
                         size=part.size,
                         files=part.files,
@@ -248,7 +248,7 @@ def deduplicate_parts(
             name=existing_part["name"],
             checksum=existing_part["checksum"],
             size=int(existing_part["size"]),
-            link=existing_part["backup_path"],
+            link=existing_part["backup_name"],
             files=existing_part["files"],
             tarball=existing_part["tarball"],
             disk_name=existing_part["disk_name"],
@@ -256,18 +256,20 @@ def deduplicate_parts(
         )
 
         if not existing_part["verified"]:
-            if not layout.check_data_part(existing_part["backup_path"], part):
+            if not layout.check_data_part(existing_part["backup_name"], part):
                 logging.debug(
-                    'Part "{}" found in "{}", but it\'s invalid, skipping',
+                    'Part "{}" found in backup "{}", but it\'s invalid, skipping',
                     part.name,
-                    existing_part["backup_path"],
+                    existing_part["backup_name"],
                 )
                 continue
 
         deduplicated_parts[part.name] = part
 
         logging.debug(
-            'Part "{}" found in "{}", reusing', part.name, existing_part["backup_path"]
+            'Part "{}" found in backup "{}", reusing',
+            part.name,
+            existing_part["backup_name"],
         )
 
     return deduplicated_parts
@@ -286,9 +288,7 @@ def collect_dedup_references_for_batch_backup_deletion(
         _create_empty_dedup_references
     )
 
-    deleting_backup_name_resolver = {
-        b.path: b.name for b in deleting_backups_light_meta
-    }
+    deleting_backup_names = {b.name for b in deleting_backups_light_meta}
     for backup in retained_backups_light_meta:
         backup = layout.reload_backup(backup, use_light_meta=False)
         for db_name in backup.get_databases():
@@ -297,11 +297,10 @@ def collect_dedup_references_for_batch_backup_deletion(
                     if not part.link:
                         continue
 
-                    backup_name = deleting_backup_name_resolver.get(part.link)
-                    if not backup_name:
+                    if part.link not in deleting_backup_names:
                         continue
 
-                    _add_part_to_dedup_references(dedup_references[backup_name], part)
+                    _add_part_to_dedup_references(dedup_references[part.link], part)
 
     return dedup_references
 

--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -331,7 +331,9 @@ class BackupLayout:
         """
         Download named collection create statement.
         """
-        remote_path = _named_collections_data_path(self.get_backup_path(backup_meta.name), filename)
+        remote_path = _named_collections_data_path(
+            self.get_backup_path(backup_meta.name), filename
+        )
         return self._storage_loader.download_data(remote_path, encryption=True)
 
     def get_backup_names(self) -> Sequence[str]:
@@ -463,7 +465,9 @@ class BackupLayout:
         """
         Download and return table create statement.
         """
-        remote_path = _table_metadata_path(self.get_backup_path(backup_meta.name), db_name, table_name)
+        remote_path = _table_metadata_path(
+            self.get_backup_path(backup_meta.name), db_name, table_name
+        )
         data = self._storage_loader.download_data(
             remote_path, encryption=backup_meta.encrypted, encoding=None
         )
@@ -475,7 +479,9 @@ class BackupLayout:
         """
         Download and return table create statements.
         """
-        remote_path = _table_metadata_path_tar(self.get_backup_path(backup_meta.name), db_name)
+        remote_path = _table_metadata_path_tar(
+            self.get_backup_path(backup_meta.name), db_name
+        )
         if not self._storage_loader.path_exists(remote_path):
             logging.debug(
                 f"File {remote_path} doesn't exist, fallback to old metadata style"

--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -304,7 +304,7 @@ class BackupLayout:
         Download user defined function create statement.
         """
         remote_path = self._get_escaped_if_exists(
-            _udf_data_path, backup_meta.path, filename
+            _udf_data_path, self.get_backup_path(backup_meta.name), filename
         )
         return self._storage_loader.download_data(remote_path, encryption=True)
 
@@ -331,7 +331,7 @@ class BackupLayout:
         """
         Download named collection create statement.
         """
-        remote_path = _named_collections_data_path(backup_meta.path, filename)
+        remote_path = _named_collections_data_path(self.get_backup_path(backup_meta.name), filename)
         return self._storage_loader.download_data(remote_path, encryption=True)
 
     def get_backup_names(self) -> Sequence[str]:
@@ -419,7 +419,7 @@ class BackupLayout:
         """
         Download and return database create statement.
         """
-        remote_path = _db_metadata_path(backup_meta.path, db_name)
+        remote_path = _db_metadata_path(self.get_backup_path(backup_meta.name), db_name)
         return self._storage_loader.download_data(
             remote_path, encryption=backup_meta.encrypted
         )
@@ -430,7 +430,7 @@ class BackupLayout:
         """
         Download and return database create statements.
         """
-        remote_path = _db_metadata_path_tar(backup_meta.path)
+        remote_path = _db_metadata_path_tar(self.get_backup_path(backup_meta.name))
         if not self._storage_loader.path_exists(remote_path):
             logging.debug(
                 f"File {remote_path} doesn't exist, fallback to old metadata style"
@@ -463,7 +463,7 @@ class BackupLayout:
         """
         Download and return table create statement.
         """
-        remote_path = _table_metadata_path(backup_meta.path, db_name, table_name)
+        remote_path = _table_metadata_path(self.get_backup_path(backup_meta.name), db_name, table_name)
         data = self._storage_loader.download_data(
             remote_path, encryption=backup_meta.encrypted, encoding=None
         )
@@ -475,7 +475,7 @@ class BackupLayout:
         """
         Download and return table create statements.
         """
-        remote_path = _table_metadata_path_tar(backup_meta.path, db_name)
+        remote_path = _table_metadata_path_tar(self.get_backup_path(backup_meta.name), db_name)
         if not self._storage_loader.path_exists(remote_path):
             logging.debug(
                 f"File {remote_path} doesn't exist, fallback to old metadata style"
@@ -555,7 +555,7 @@ class BackupLayout:
 
         remote_dir_path = self._get_escaped_if_exists(
             _part_path,
-            part.link or backup_meta.path,
+            part.link or self.get_backup_path(backup_meta.name),
             part.database,
             part.table,
             part.name,
@@ -754,7 +754,7 @@ class BackupLayout:
         for part in parts:
             part_path = self._get_escaped_if_exists(
                 _part_path,
-                part.link or backup_meta.path,
+                part.link or self.get_backup_path(backup_meta.name),
                 part.database,
                 part.table,
                 part.name,

--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -560,13 +560,24 @@ class BackupLayout:
         os.makedirs(fs_part_path, exist_ok=True)
 
         # See PartMetadata.link for the semantics of part.link.
+        backup_path = self._resolve_part_backup_path(backup_meta.name, part.link)
         remote_dir_path = self._get_escaped_if_exists(
             _part_path,
-            part.link or self.get_backup_path(backup_meta.name),
+            backup_path,
             part.database,
             part.table,
             part.name,
         )
+        if part.link:
+            logging.debug(
+                'Resolved deduplicated part link for "{}"."{}" part {}: raw_link={}, backup_path={}, remote_dir_path={}',
+                part.database,
+                part.table,
+                part.name,
+                part.link,
+                backup_path,
+                remote_dir_path,
+            )
 
         if part.tarball:
             remote_path = os.path.join(remote_dir_path, f"{part.name}.tar")
@@ -604,9 +615,10 @@ class BackupLayout:
         """
         try:
             # See PartMetadata.link for the semantics of part.link.
+            resolved_backup_path = self._resolve_part_backup_path(None, part.link, backup_path)
             remote_dir_path = self._get_escaped_if_exists(
                 _part_path,
-                part.link or backup_path,
+                resolved_backup_path,
                 part.database,
                 part.table,
                 part.name,
@@ -759,9 +771,10 @@ class BackupLayout:
         deleting_files: List[str] = []
         for part in parts:
             # See PartMetadata.link for the semantics of part.link.
+            resolved_backup_path = self._resolve_part_backup_path(None, part.link, backup_path)
             part_path = self._get_escaped_if_exists(
                 _part_path,
-                part.link or backup_path,
+                resolved_backup_path,
                 part.database,
                 part.table,
                 part.name,
@@ -832,6 +845,43 @@ class BackupLayout:
         if self._storage_loader.path_exists(path, is_dir=True):
             return path
         return path_function(*args, escape_names=False, **kwargs)
+
+    def _resolve_part_backup_path(
+        self,
+        backup_name: Optional[str],
+        part_link: Optional[str],
+        default_backup_path: Optional[str] = None,
+    ) -> str:
+        """
+        Resolve backup path for a part, normalizing historical malformed links.
+        """
+        if not part_link:
+            if default_backup_path:
+                return default_backup_path
+            assert backup_name is not None
+            return self.get_backup_path(backup_name)
+
+        path_root = self._config["path_root"]
+        if not path_root:
+            return part_link
+
+        normalized_root = path_root.strip("/")
+        normalized_link = part_link.strip("/")
+
+        if normalized_link == normalized_root or normalized_link.startswith(
+            normalized_root + "/"
+        ):
+            return normalized_link
+
+        root_marker = f"/{normalized_root}/"
+        if root_marker in f"/{normalized_link}":
+            _, suffix = normalized_link.split(f"{normalized_root}/", 1)
+            return f"{normalized_root}/{suffix}"
+
+        if "/" not in normalized_link:
+            return self.get_backup_path(normalized_link)
+
+        return normalized_link
 
 
 def _access_control_data_path(backup_path: str, file_name: str) -> str:

--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -559,6 +559,7 @@ class BackupLayout:
 
         os.makedirs(fs_part_path, exist_ok=True)
 
+        # See PartMetadata.link for the semantics of part.link.
         remote_dir_path = self._get_escaped_if_exists(
             _part_path,
             part.link or self.get_backup_path(backup_meta.name),
@@ -602,6 +603,7 @@ class BackupLayout:
         Check availability of part data in storage.
         """
         try:
+            # See PartMetadata.link for the semantics of part.link.
             remote_dir_path = self._get_escaped_if_exists(
                 _part_path,
                 part.link or backup_path,
@@ -647,18 +649,15 @@ class BackupLayout:
         source_disk_name: str,
         compression: bool,
     ) -> Sequence[str]:
+        backup_path = self.get_backup_path(backup_name)
         # Check if metadata is stored as 'disks/s3.tar.gz' for backwards compatibility
         old_style_remote_path = _disk_metadata_path(
-            self.get_backup_path(backup_name), None, None, source_disk_name, compression
+            backup_path, None, None, source_disk_name, compression
         )
         if self._storage_loader.path_exists(old_style_remote_path):
             return [old_style_remote_path]
         return self._storage_loader.list_dir(
-            str(
-                os.path.join(
-                    self.get_backup_path(backup_name), "disks", source_disk_name
-                )
-            ),
+            str(os.path.join(backup_path, "disks", source_disk_name)),
             recursive=True,
             absolute=True,
         )
@@ -756,11 +755,13 @@ class BackupLayout:
         if not parts:
             return
 
+        backup_path = self.get_backup_path(backup_meta.name)
         deleting_files: List[str] = []
         for part in parts:
+            # See PartMetadata.link for the semantics of part.link.
             part_path = self._get_escaped_if_exists(
                 _part_path,
-                part.link or self.get_backup_path(backup_meta.name),
+                part.link or backup_path,
                 part.database,
                 part.table,
                 part.name,

--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -559,8 +559,9 @@ class BackupLayout:
 
         os.makedirs(fs_part_path, exist_ok=True)
 
-        # See PartMetadata.link for the semantics of part.link.
-        backup_path = self._resolve_part_backup_path(backup_meta.name, part.link)
+        # part.link is the source backup name for deduplicated parts (or None).
+        source_backup_name = part.link or backup_meta.name
+        backup_path = self.get_backup_path(source_backup_name)
         remote_dir_path = self._get_escaped_if_exists(
             _part_path,
             backup_path,
@@ -568,16 +569,6 @@ class BackupLayout:
             part.table,
             part.name,
         )
-        if part.link:
-            logging.debug(
-                'Resolved deduplicated part link for "{}"."{}" part {}: raw_link={}, backup_path={}, remote_dir_path={}',
-                part.database,
-                part.table,
-                part.name,
-                part.link,
-                backup_path,
-                remote_dir_path,
-            )
 
         if part.tarball:
             remote_path = os.path.join(remote_dir_path, f"{part.name}.tar")
@@ -609,13 +600,14 @@ class BackupLayout:
                     msg = f"Failed to download part file {remote_path}"
                     raise StorageError(msg) from e
 
-    def check_data_part(self, backup_path: str, part: PartMetadata) -> bool:
+    def check_data_part(self, backup_name: str, part: PartMetadata) -> bool:
         """
         Check availability of part data in storage.
         """
         try:
-            # See PartMetadata.link for the semantics of part.link.
-            resolved_backup_path = self._resolve_part_backup_path(None, part.link, backup_path)
+            # part.link is the source backup name for deduplicated parts (or None).
+            source_backup_name = part.link or backup_name
+            resolved_backup_path = self.get_backup_path(source_backup_name)
             remote_dir_path = self._get_escaped_if_exists(
                 _part_path,
                 resolved_backup_path,
@@ -767,14 +759,13 @@ class BackupLayout:
         if not parts:
             return
 
-        backup_path = self.get_backup_path(backup_meta.name)
         deleting_files: List[str] = []
         for part in parts:
-            # See PartMetadata.link for the semantics of part.link.
-            resolved_backup_path = self._resolve_part_backup_path(None, part.link, backup_path)
+            # part.link is the source backup name for deduplicated parts (or None).
+            source_backup_name = part.link or backup_meta.name
             part_path = self._get_escaped_if_exists(
                 _part_path,
-                resolved_backup_path,
+                self.get_backup_path(source_backup_name),
                 part.database,
                 part.table,
                 part.name,
@@ -845,43 +836,6 @@ class BackupLayout:
         if self._storage_loader.path_exists(path, is_dir=True):
             return path
         return path_function(*args, escape_names=False, **kwargs)
-
-    def _resolve_part_backup_path(
-        self,
-        backup_name: Optional[str],
-        part_link: Optional[str],
-        default_backup_path: Optional[str] = None,
-    ) -> str:
-        """
-        Resolve backup path for a part, normalizing historical malformed links.
-        """
-        if not part_link:
-            if default_backup_path:
-                return default_backup_path
-            assert backup_name is not None
-            return self.get_backup_path(backup_name)
-
-        path_root = self._config["path_root"]
-        if not path_root:
-            return part_link
-
-        normalized_root = path_root.strip("/")
-        normalized_link = part_link.strip("/")
-
-        if normalized_link == normalized_root or normalized_link.startswith(
-            normalized_root + "/"
-        ):
-            return normalized_link
-
-        root_marker = f"/{normalized_root}/"
-        if root_marker in f"/{normalized_link}":
-            _, suffix = normalized_link.split(f"{normalized_root}/", 1)
-            return f"{normalized_root}/{suffix}"
-
-        if "/" not in normalized_link:
-            return self.get_backup_path(normalized_link)
-
-        return normalized_link
 
 
 def _access_control_data_path(backup_path: str, file_name: str) -> str:

--- a/ch_backup/backup/metadata/__init__.py
+++ b/ch_backup/backup/metadata/__init__.py
@@ -6,5 +6,5 @@ from ch_backup.backup.metadata.access_control_metadata import AccessControlMetad
 from ch_backup.backup.metadata.backup_metadata import BackupMetadata, BackupState
 from ch_backup.backup.metadata.cloud_storage_metadata import CloudStorageMetadata
 from ch_backup.backup.metadata.common import BackupStorageFormat
-from ch_backup.backup.metadata.part_metadata import PartMetadata
+from ch_backup.backup.metadata.part_metadata import PartMetadata, normalize_backup_link
 from ch_backup.backup.metadata.table_metadata import TableMetadata

--- a/ch_backup/backup/metadata/backup_metadata.py
+++ b/ch_backup/backup/metadata/backup_metadata.py
@@ -41,7 +41,6 @@ class BackupMetadata:
     def __init__(
         self,
         name: str,
-        path: str,
         version: str,
         ch_version: str,
         time_format: str,
@@ -51,7 +50,6 @@ class BackupMetadata:
         encrypted: bool = True,
     ) -> None:
         self.name = name
-        self.path = path
         self.version = version
         self.ch_version = ch_version
         self.hostname = hostname or socket.getfqdn()
@@ -131,7 +129,6 @@ class BackupMetadata:
             "cloud_storage": self.cloud_storage.dump(),
             "meta": {
                 "name": self.name,
-                "path": self.path,
                 "version": self.version,
                 "ch_version": self.ch_version,
                 "hostname": self.hostname,
@@ -229,7 +226,6 @@ class BackupMetadata:
 
             backup = cls.__new__(cls)
             backup.name = meta["name"]
-            backup.path = meta["path"]
             backup.hostname = meta["hostname"]
             backup.time_format = meta["time_format"]
             backup._databases = data["databases"]

--- a/ch_backup/backup/metadata/backup_metadata.py
+++ b/ch_backup/backup/metadata/backup_metadata.py
@@ -2,7 +2,9 @@
 Backup metadata.
 """
 
+import copy
 import json
+import os
 import socket
 from datetime import datetime, timezone
 from enum import Enum
@@ -48,8 +50,17 @@ class BackupMetadata:
         labels: dict = None,
         schema_only: bool = False,
         encrypted: bool = True,
+        path: Optional[str] = None,
     ) -> None:
         self.name = name
+        # DEPRECATED: ``path`` is kept solely for backward compatibility with
+        # older versions of ch-backup that read the full backup path from
+        # metadata. New code MUST NOT rely on it — use ``name`` instead and
+        # resolve the storage path through ``BackupLayout.get_backup_path()``.
+        # TODO: remove the ``path`` field completely in a few releases once
+        #       all running hosts are guaranteed to be on a version that does
+        #       not read it.  Tracked in a separate ticket.
+        self.path = path if path is not None else name
         self.version = version
         self.ch_version = ch_version
         self.hostname = hostname or socket.getfqdn()
@@ -121,14 +132,27 @@ class BackupMetadata:
         """
         Serialize backup metadata.
         """
+        if light:
+            databases: Dict[str, dict] = {}
+        else:
+            # Rewrite ``link`` of every part from a plain backup name back to a
+            # full storage path (``<path_root>/<source_backup_name>``) so that
+            # older ch-backup versions, which expect the legacy full-path
+            # format, can still read backups produced by this version.
+            # DEPRECATED: this conversion will be removed once the legacy
+            # format is no longer supported.
+            databases = self._databases_with_legacy_part_links()
+
         return {
-            "databases": self._databases if not light else {},
+            "databases": databases,
             "access_controls": self._access_control.dump() if not light else {},
             "user_defined_functions": self._user_defined_functions if not light else [],
             "named_collections": self._named_collections if not light else [],
             "cloud_storage": self.cloud_storage.dump(),
             "meta": {
                 "name": self.name,
+                # DEPRECATED: kept for backward compatibility; see __init__.
+                "path": self.path,
                 "version": self.version,
                 "ch_version": self.ch_version,
                 "hostname": self.hostname,
@@ -147,6 +171,35 @@ class BackupMetadata:
                 "encrypted": self.encrypted,
             },
         }
+
+    def _databases_with_legacy_part_links(self) -> Dict[str, dict]:
+        """
+        Return a deep-copy of ``self._databases`` where every part's ``link``
+        field is rewritten from a plain backup name (new format) to a full
+        storage path (legacy format).
+
+        Required for backward compatibility with ch-backup versions that
+        still read the ``link`` field as a full storage path.
+        """
+        # ``self.path`` is in the form "<path_root>/<backup_name>". Strip the
+        # backup name to obtain the path root that prefixes any source backup.
+        path_root = os.path.dirname(self.path) if self.path else ""
+
+        databases = copy.deepcopy(self._databases)
+        # Defensive: in some test fixtures ``_databases`` may be an empty list.
+        if not isinstance(databases, dict):
+            return databases
+        for db in databases.values():
+            for table in db.get("tables", {}).values():
+                for part in table.get("parts", {}).values():
+                    link = part.get("link")
+                    if not link:
+                        continue
+                    # Skip already legacy-formatted links (defensive).
+                    if "/" in link:
+                        continue
+                    part["link"] = os.path.join(path_root, link) if path_root else link
+        return databases
 
     def dump_json(
         self,
@@ -226,6 +279,10 @@ class BackupMetadata:
 
             backup = cls.__new__(cls)
             backup.name = meta["name"]
+            # DEPRECATED: kept for backward compatibility — fall back to the
+            # backup name when the legacy ``path`` field is missing (new
+            # backups still write it for forward compatibility).
+            backup.path = meta.get("path", meta["name"])
             backup.hostname = meta["hostname"]
             backup.time_format = meta["time_format"]
             backup._databases = data["databases"]

--- a/ch_backup/backup/metadata/part_metadata.py
+++ b/ch_backup/backup/metadata/part_metadata.py
@@ -126,8 +126,8 @@ class PartMetadata(Slotted):
         backup name.  ``os.path.basename`` transparently converts both formats
         to a plain backup name.
         """
-        raw_link = raw_metadata["link"]
-        link = os.path.basename(raw_link) if raw_link else None
+        raw_link = raw_metadata.get("link")
+        link = os.path.basename(raw_link.rstrip("/")) if raw_link else None
         return cls(
             database=db_name,
             table=table_name,

--- a/ch_backup/backup/metadata/part_metadata.py
+++ b/ch_backup/backup/metadata/part_metadata.py
@@ -135,10 +135,7 @@ class PartMetadata(Slotted):
     ) -> "PartMetadata":
         """
         Deserialize data part metadata.
-
-        The ``link`` field is normalized via :func:`normalize_backup_link`.
         """
-        link = normalize_backup_link(raw_metadata.get("link"))
         return cls(
             database=db_name,
             table=table_name,
@@ -147,7 +144,7 @@ class PartMetadata(Slotted):
             size=raw_metadata["bytes"],
             files=raw_metadata["files"],
             tarball=raw_metadata.get("tarball", False),
-            link=link,
+            link=normalize_backup_link(raw_metadata.get("link")),
             disk_name=raw_metadata.get("disk_name", "default"),
             encrypted=raw_metadata.get("encrypted", True),
         )

--- a/ch_backup/backup/metadata/part_metadata.py
+++ b/ch_backup/backup/metadata/part_metadata.py
@@ -13,9 +13,15 @@ def normalize_backup_link(raw_link: Optional[str]) -> Optional[str]:
     """
     Normalize the ``link`` field to a plain backup name.
 
-    Old backups stored a full storage path (e.g. ``/srv/backups/20181017T210300``
-    or ``ch_backup/20181017T210300``); new backups store just the backup name.
-    ``os.path.basename`` transparently converts both formats to a plain name.
+    The serialized ``link`` field is intentionally stored as a full storage
+    path (legacy format) so that older ch-backup versions can still read
+    backups produced by this code.  In-memory we always work with a plain
+    backup name; this helper performs the conversion at load time.
+
+    ``os.path.basename`` handles both formats transparently:
+    - ``"20181017T210300"``                 → ``"20181017T210300"`` (new)
+    - ``"ch_backup/20181017T210300"``       → ``"20181017T210300"`` (legacy)
+    - ``"/srv/backups/20181017T210300/"``   → ``"20181017T210300"`` (legacy)
 
     Returns ``None`` for falsy values (``None``, empty string).
     """

--- a/ch_backup/backup/metadata/part_metadata.py
+++ b/ch_backup/backup/metadata/part_metadata.py
@@ -87,7 +87,9 @@ class PartMetadata(Slotted):
     @property
     def link(self) -> Optional[str]:
         """
-        For deduplicated data parts it returns link to the source backup (its path). Otherwise None is returned.
+        For deduplicated data parts returns the resolved path to the source backup
+        (same format as ``BackupLayout.get_backup_path()``). For non-deduplicated
+        parts returns None.
         """
         return self.raw_metadata.link
 

--- a/ch_backup/backup/metadata/part_metadata.py
+++ b/ch_backup/backup/metadata/part_metadata.py
@@ -9,6 +9,21 @@ from ch_backup.clickhouse.models import FrozenPart
 from ch_backup.util import Slotted
 
 
+def normalize_backup_link(raw_link: Optional[str]) -> Optional[str]:
+    """
+    Normalize the ``link`` field to a plain backup name.
+
+    Old backups stored a full storage path (e.g. ``/srv/backups/20181017T210300``
+    or ``ch_backup/20181017T210300``); new backups store just the backup name.
+    ``os.path.basename`` transparently converts both formats to a plain name.
+
+    Returns ``None`` for falsy values (``None``, empty string).
+    """
+    if not raw_link:
+        return None
+    return os.path.basename(raw_link.rstrip("/"))
+
+
 class RawMetadata(Slotted):
     """
     Raw metadata for ClickHouse data part.
@@ -121,13 +136,9 @@ class PartMetadata(Slotted):
         """
         Deserialize data part metadata.
 
-        Normalizes the ``link`` field: old backups stored a full storage path
-        (e.g. ``/srv/backups/20181017T210300``); new backups store just the
-        backup name.  ``os.path.basename`` transparently converts both formats
-        to a plain backup name.
+        The ``link`` field is normalized via :func:`normalize_backup_link`.
         """
-        raw_link = raw_metadata.get("link")
-        link = os.path.basename(raw_link.rstrip("/")) if raw_link else None
+        link = normalize_backup_link(raw_metadata.get("link"))
         return cls(
             database=db_name,
             table=table_name,

--- a/ch_backup/backup/metadata/part_metadata.py
+++ b/ch_backup/backup/metadata/part_metadata.py
@@ -2,6 +2,7 @@
 Backup metadata for ClickHouse data part.
 """
 
+import os
 from typing import Optional, Sequence
 
 from ch_backup.clickhouse.models import FrozenPart
@@ -22,8 +23,8 @@ class RawMetadata(Slotted):
         size: int,
         files: Sequence[str],
         tarball: bool,
-        link: str = None,
-        disk_name: str = None,
+        link: Optional[str] = None,
+        disk_name: Optional[str] = None,
         encrypted: bool = True,
     ) -> None:
         self.checksum = checksum
@@ -52,8 +53,8 @@ class PartMetadata(Slotted):
         size: int,
         files: Sequence[str],
         tarball: bool,
-        link: str = None,
-        disk_name: str = None,
+        link: Optional[str] = None,
+        disk_name: Optional[str] = None,
         encrypted: bool = True,
     ) -> None:
         self.database: str = database
@@ -87,9 +88,8 @@ class PartMetadata(Slotted):
     @property
     def link(self) -> Optional[str]:
         """
-        For deduplicated data parts returns the resolved path to the source backup
-        (same format as ``BackupLayout.get_backup_path()``). For non-deduplicated
-        parts returns None.
+        For deduplicated data parts returns the name of the source backup.
+        For non-deduplicated parts returns None.
         """
         return self.raw_metadata.link
 
@@ -120,7 +120,14 @@ class PartMetadata(Slotted):
     ) -> "PartMetadata":
         """
         Deserialize data part metadata.
+
+        Normalizes the ``link`` field: old backups stored a full storage path
+        (e.g. ``/srv/backups/20181017T210300``); new backups store just the
+        backup name.  ``os.path.basename`` transparently converts both formats
+        to a plain backup name.
         """
+        raw_link = raw_metadata["link"]
+        link = os.path.basename(raw_link) if raw_link else None
         return cls(
             database=db_name,
             table=table_name,
@@ -129,7 +136,7 @@ class PartMetadata(Slotted):
             size=raw_metadata["bytes"],
             files=raw_metadata["files"],
             tarball=raw_metadata.get("tarball", False),
-            link=raw_metadata["link"],
+            link=link,
             disk_name=raw_metadata.get("disk_name", "default"),
             encrypted=raw_metadata.get("encrypted", True),
         )

--- a/ch_backup/ch_backup.py
+++ b/ch_backup/ch_backup.py
@@ -159,7 +159,6 @@ class ClickhouseBackup:
 
         self._context.backup_meta = BackupMetadata(
             name=name,
-            path=self._context.backup_layout.get_backup_path(name),
             labels=backup_labels,
             version=get_version(),
             ch_version=self._context.ch_ctl.get_version(),
@@ -278,7 +277,7 @@ class ClickhouseBackup:
                 logging.critical(
                     "Required databases %s were not found in backup metadata: %s",
                     ", ".join(missed_databases),
-                    self._context.backup_meta.path,
+                    self._context.backup_meta.name,
                 )
                 raise ClickhouseBackupError(
                     "Required databases were not found in backup metadata"

--- a/ch_backup/ch_backup.py
+++ b/ch_backup/ch_backup.py
@@ -159,6 +159,9 @@ class ClickhouseBackup:
 
         self._context.backup_meta = BackupMetadata(
             name=name,
+            # DEPRECATED: ``path`` is populated for backward compatibility
+            # with older ch-backup versions and is not used by new code.
+            path=self._context.backup_layout.get_backup_path(name),
             labels=backup_labels,
             version=get_version(),
             ch_version=self._context.ch_ctl.get_version(),

--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -324,7 +324,7 @@ CREATE_IF_NOT_EXISTS_DEDUP_TABLE_SQL = strip_query(
         database String,
         table String,
         name String,
-        backup_path String,
+        backup_name String,
         checksum String,
         size Int64,
         files Array(String),

--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -547,7 +547,7 @@ class TableBackup(BackupManager):
 
             for part in uploaded_parts:
                 if not context.backup_layout.check_data_part(
-                    context.backup_layout.get_backup_path(context.backup_meta.name),
+                    context.backup_meta.name,
                     part,
                 ):
                     invalid_parts.append(part)

--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -547,7 +547,7 @@ class TableBackup(BackupManager):
 
             for part in uploaded_parts:
                 if not context.backup_layout.check_data_part(
-                    context.backup_meta.path, part
+                    context.backup_layout.get_backup_path(context.backup_meta.name), part
                 ):
                     invalid_parts.append(part)
 

--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -547,7 +547,8 @@ class TableBackup(BackupManager):
 
             for part in uploaded_parts:
                 if not context.backup_layout.check_data_part(
-                    context.backup_layout.get_backup_path(context.backup_meta.name), part
+                    context.backup_layout.get_backup_path(context.backup_meta.name),
+                    part,
                 ):
                     invalid_parts.append(part)
 

--- a/ch_backup/logic/upload_part_observer.py
+++ b/ch_backup/logic/upload_part_observer.py
@@ -3,7 +3,7 @@
 import time
 from typing import List
 
-from ch_backup.backup.metadata.part_metadata import PartMetadata
+from ch_backup.backup.metadata import PartMetadata
 from ch_backup.backup_context import BackupContext
 
 

--- a/tests/integration/features/backward_compatibility.feature
+++ b/tests/integration/features/backward_compatibility.feature
@@ -16,7 +16,7 @@ Feature: Backward compatibility support for old backups
     encryption:
       enabled: False
     """
-    
+
 
   Scenario: Restore with old metadata layout
     When we execute queries on clickhouse01
@@ -67,3 +67,98 @@ Feature: Backward compatibility support for old backups
     """
     When we restore clickhouse backup #0 to clickhouse02
     Then clickhouse02 has same schema as clickhouse01
+
+  # Regression: part.link used to store a full storage path (e.g. "ch_backup/<name>").
+  # After the path→name refactor, normalize_backup_link() must transparently convert
+  # the old format so that:
+  #   1. restore of a legacy links-backup works (PartMetadata.load + download_data_part);
+  #   2. a new incremental backup on top of a legacy chain still deduplicates correctly
+  #      (dedup table read path in _populate_dedup_info);
+  #   3. validate_part_after_upload passes for the new incremental backup.
+  Scenario: Legacy full-path links are normalised for restore, dedup and validation
+    Given we have executed queries on clickhouse01
+    """
+    CREATE DATABASE test_db_legacy;
+    CREATE TABLE test_db_legacy.tbl (id UInt32, val String)
+    ENGINE = MergeTree ORDER BY id;
+    INSERT INTO test_db_legacy.tbl SELECT number, toString(number) FROM system.numbers LIMIT 20;
+    """
+    And ch-backup configuration on clickhouse01
+    """
+    backup:
+        deduplicate_parts: True
+        validate_part_after_upload: True
+    """
+    # Backup #1 — shared backup (new format, no links).
+    When we create clickhouse01 clickhouse backup
+    Then we got the following backups on clickhouse01
+      | num | state   | data_count | link_count |
+      | 0   | created | 1          | 0          |
+    # Backup #0 — links backup (new format, link = plain backup name).
+    When we create clickhouse01 clickhouse backup
+    Then we got the following backups on clickhouse01
+      | num | state   | data_count | link_count |
+      | 0   | created | 0          | 1          |
+      | 1   | created | 1          | 0          |
+    # Simulate old ch-backup: rewrite link values in backup #0 to full paths.
+    When part links of clickhouse01 backup #0 were rewritten to legacy path format
+    # (1) Restore of the legacy links-backup must succeed.
+    When we restore clickhouse backup #0 to clickhouse02
+    Then we got same clickhouse data at clickhouse01 clickhouse02
+    # (2+3) Create another incremental backup on top of the legacy-format chain.
+    # Dedup must normalise the legacy link and produce link_count > 0;
+    # validate_part_after_upload must also pass.
+    When we create clickhouse01 clickhouse backup
+    Then we got the following backups on clickhouse01
+      | num | state   | data_count | link_count |
+      | 0   | created | 0          | 1          |
+      | 1   | created | 0          | 1          |
+      | 2   | created | 1          | 0          |
+    When we restore clickhouse backup #0 to clickhouse02
+    Then we got same clickhouse data at clickhouse01 clickhouse02
+
+  # Regression: purge/delete must correctly identify which parts are referenced
+  # by a links-backup even when those links are stored in the legacy full-path
+  # format.  If normalize_backup_link() is not applied, the dedup-reference
+  # collector will fail to match the link against the set of backup names and
+  # will incorrectly delete the shared data parts.
+  Scenario: Purge mixed-format chain does not delete referenced parts
+    Given we have executed queries on clickhouse01
+    """
+    CREATE DATABASE test_db_purge;
+    CREATE TABLE test_db_purge.tbl (id UInt32, val String)
+    ENGINE = MergeTree ORDER BY id;
+    INSERT INTO test_db_purge.tbl SELECT number, toString(number) FROM system.numbers LIMIT 20;
+    """
+    And ch-backup configuration on clickhouse01
+    """
+    backup:
+        deduplicate_parts: True
+        retain_count: 1
+        retain_time:
+            days: 0
+            seconds: 0
+    """
+    # Backup #1 — shared backup (new format).
+    When we create clickhouse01 clickhouse backup
+    # Backup #0 — links backup (new format).
+    When we create clickhouse01 clickhouse backup
+    Then we got the following backups on clickhouse01
+      | num | state   | data_count | link_count |
+      | 0   | created | 0          | 1          |
+      | 1   | created | 1          | 0          |
+    # Simulate legacy format: rewrite links in backup #0 to full paths.
+    When part links of clickhouse01 backup #0 were rewritten to legacy path format
+    # Purge should keep backup #0 (newest) and attempt to delete backup #1.
+    # Because backup #0 still references backup #1's data parts (via legacy links),
+    # backup #1 must become partially_deleted (data preserved) rather than fully removed.
+    # This proves that normalize_backup_link() correctly resolves the legacy link so
+    # that collect_dedup_references_for_batch_backup_deletion() protects the shared parts.
+    When we purge clickhouse01 clickhouse backups
+    Then we got the following backups on clickhouse01
+      | num | state             | data_count | link_count |
+      | 0   | created           | 0          | 1          |
+      | 1   | partially_deleted | 1          | 0          |
+    # Restore must succeed — the referenced data parts must still be present in S3.
+    When we restore clickhouse backup #0 to clickhouse02
+    Then we got same clickhouse data at clickhouse01 clickhouse02

--- a/tests/integration/modules/ch_backup.py
+++ b/tests/integration/modules/ch_backup.py
@@ -123,19 +123,23 @@ class Backup:
         """
         return self.meta.get("time_format")
 
-    @property
-    def metadata_path(self) -> str:
+    def get_backup_path(self, path_root: str) -> str:
+        """
+        Compute backup storage path from path_root and backup name.
+        """
+        return os.path.join(path_root, self.name)
+
+    def metadata_path(self, path_root: str) -> str:
         """
         Path to full backup metadata file.
         """
-        return os.path.join(self.meta["path"], "backup_struct.json")
+        return os.path.join(self.get_backup_path(path_root), "backup_struct.json")
 
-    @property
-    def light_metadata_path(self) -> str:
+    def light_metadata_path(self, path_root: str) -> str:
         """
         Path to light backup metadata file.
         """
-        return os.path.join(self.meta["path"], "backup_light_struct.json")
+        return os.path.join(self.get_backup_path(path_root), "backup_light_struct.json")
 
     def update(self, metadata: dict, merge: bool = True) -> None:
         """
@@ -157,11 +161,11 @@ class Backup:
 
         return json.dumps(metadata, indent=indent)
 
-    def get_file_paths(self) -> Sequence[str]:
+    def get_file_paths(self, path_root: str) -> Sequence[str]:
         """
         Return all storage paths
         """
-        backup_path = self.meta["path"]
+        backup_path = self.get_backup_path(path_root)
         cloud_stage_disks = set(self._metadata["cloud_storage"]["disks"])
         file_paths: Set[str] = set()
         for db_name, db_obj in self._metadata["databases"].items():
@@ -170,8 +174,15 @@ class Backup:
                     # Skip S3 parts.
                     if part_obj.get("disk_name") in cloud_stage_disks:
                         continue
+                    # part_obj["link"] may be a full path (old format) or a backup name
+                    # (new format). Normalise to a plain backup name via basename.
+                    raw_link = part_obj.get("link")
+                    link_name = os.path.basename(raw_link) if raw_link else None
+                    source_path = (
+                        os.path.join(path_root, link_name) if link_name else backup_path
+                    )
                     part_path = os.path.join(
-                        part_obj.get("link") or backup_path,
+                        source_path,
                         "data",
                         _quote(db_name),
                         _quote(table_name),
@@ -198,6 +209,12 @@ class BackupManager:
         self._config_path = CH_BACKUP_CONF_PATH
         protocol = context.ch_backup["protocol"]
         self._cmd_base = f"timeout {timeout} {CH_BACKUP_CLI_PATH} --protocol {protocol} --insecure  --config {self._config_path}"
+        # Read path_root from the ch-backup config on the container.
+        conf_output = self._container.exec_run(
+            f"/bin/cat {self._config_path}", user="root"
+        ).output.decode()
+        conf = yaml.load(conf_output, yaml.SafeLoader)
+        self._path_root: str = conf.get("backup", {}).get("path_root", "ch_backup/")
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def backup(
@@ -384,10 +401,12 @@ class BackupManager:
         backup = self.get_backup(backup_id)
         backup.update(metadata, merge)
         self._s3_client.upload_data(
-            backup.dump_json(light=False).encode("utf-8"), backup.metadata_path
+            backup.dump_json(light=False).encode("utf-8"),
+            backup.metadata_path(self._path_root),
         )
         self._s3_client.upload_data(
-            backup.dump_json(light=True).encode("utf-8"), backup.light_metadata_path
+            backup.dump_json(light=True).encode("utf-8"),
+            backup.light_metadata_path(self._path_root),
         )
 
     def delete_backup_metadata_paths(
@@ -407,10 +426,12 @@ class BackupManager:
         for path in paths:
             delete_path(backup.metadata, path.split("."))
         self._s3_client.upload_data(
-            backup.dump_json(light=False).encode("utf-8"), backup.metadata_path
+            backup.dump_json(light=False).encode("utf-8"),
+            backup.metadata_path(self._path_root),
         )
         self._s3_client.upload_data(
-            backup.dump_json(light=True).encode("utf-8"), backup.light_metadata_path
+            backup.dump_json(light=True).encode("utf-8"),
+            backup.light_metadata_path(self._path_root),
         )
 
     def delete_backup_file(self, backup_id: BackupId, path: str) -> None:
@@ -418,14 +439,18 @@ class BackupManager:
         Delete particular file from backup (useful for fault injection).
         """
         backup = self.get_backup(backup_id)
-        self._s3_client.delete_data(os.path.join(backup.meta["path"], path))
+        self._s3_client.delete_data(
+            os.path.join(backup.get_backup_path(self._path_root), path)
+        )
 
     def set_backup_file_data(self, backup_id: BackupId, path: str, data: bytes) -> None:
         """
         Set particular file data in backup (useful for fault injection).
         """
         backup = self.get_backup(backup_id)
-        self._s3_client.upload_data(data, os.path.join(backup.meta["path"], path))
+        self._s3_client.upload_data(
+            data, os.path.join(backup.get_backup_path(self._path_root), path)
+        )
 
     def get_missed_paths(self, backup_id: BackupId) -> Sequence[str]:
         """
@@ -433,7 +458,7 @@ class BackupManager:
         """
         backup = self.get_backup(backup_id)
         missed = []
-        for path in backup.get_file_paths():
+        for path in backup.get_file_paths(self._path_root):
             if not self._s3_client.path_exists(path):
                 missed.append(path)
         return missed

--- a/tests/integration/modules/ch_backup_cli.py
+++ b/tests/integration/modules/ch_backup_cli.py
@@ -10,7 +10,7 @@ from urllib.parse import quote
 
 import yaml
 
-from ch_backup.backup.metadata.part_metadata import normalize_backup_link
+from ch_backup.backup.metadata import normalize_backup_link
 
 from . import docker, s3, utils
 from .typing import ContextT

--- a/tests/integration/modules/ch_backup_cli.py
+++ b/tests/integration/modules/ch_backup_cli.py
@@ -453,6 +453,33 @@ class BackupManager:
             data, os.path.join(backup.get_backup_path(self._path_root), path)
         )
 
+    def rewrite_part_links_to_legacy_format(self, backup_id: BackupId) -> None:
+        """
+        Rewrite all ``link`` fields in backup part metadata from the new
+        plain-name format (e.g. ``"20181017T210300"``) to the legacy full-path
+        format (e.g. ``"ch_backup/20181017T210300"``).
+
+        This is used in integration tests to simulate a backup that was created
+        by an older version of ch-backup, so that the backward-compatibility
+        path of ``normalize_backup_link()`` is exercised end-to-end.
+        """
+        backup = self.get_backup(backup_id)
+        for db_obj in backup.metadata.get("databases", {}).values():
+            for table_obj in db_obj.get("tables", {}).values():
+                for part_obj in table_obj.get("parts", {}).values():
+                    link = part_obj.get("link")
+                    if link:
+                        # Convert plain name → legacy path: "ch_backup/<name>"
+                        part_obj["link"] = os.path.join(self._path_root, link)
+        self._s3_client.upload_data(
+            backup.dump_json(light=False).encode("utf-8"),
+            backup.metadata_path(self._path_root),
+        )
+        self._s3_client.upload_data(
+            backup.dump_json(light=True).encode("utf-8"),
+            backup.light_metadata_path(self._path_root),
+        )
+
     def get_missed_paths(self, backup_id: BackupId) -> Sequence[str]:
         """
         Get backup entry metadata.

--- a/tests/integration/modules/ch_backup_cli.py
+++ b/tests/integration/modules/ch_backup_cli.py
@@ -10,6 +10,8 @@ from urllib.parse import quote
 
 import yaml
 
+from ch_backup.backup.metadata.part_metadata import normalize_backup_link
+
 from . import docker, s3, utils
 from .typing import ContextT
 
@@ -175,9 +177,8 @@ class Backup:
                     if part_obj.get("disk_name") in cloud_stage_disks:
                         continue
                     # part_obj["link"] may be a full path (old format) or a backup name
-                    # (new format). Normalise to a plain backup name via basename.
-                    raw_link = part_obj.get("link")
-                    link_name = os.path.basename(raw_link) if raw_link else None
+                    # (new format). _normalize_backup_link handles both via os.path.basename.
+                    link_name = normalize_backup_link(part_obj.get("link"))
                     source_path = (
                         os.path.join(path_root, link_name) if link_name else backup_path
                     )

--- a/tests/integration/steps/ch_backup_steps.py
+++ b/tests/integration/steps/ch_backup_steps.py
@@ -74,6 +74,18 @@ def step_backup_metadata_delete(context, node, backup_id):
     BackupManager(context, node).delete_backup_metadata_paths(backup_id, paths)
 
 
+@given("part links of {node:w} backup #{backup_id:d} were rewritten to legacy path format")
+@when("part links of {node:w} backup #{backup_id:d} were rewritten to legacy path format")
+def step_rewrite_part_links_to_legacy(context, node, backup_id):
+    """
+    Simulate a backup created by an older ch-backup version by replacing all
+    ``link`` values (plain backup names) with legacy full-path strings
+    (``<path_root>/<backup_name>``).  This exercises the backward-compatibility
+    path of ``normalize_backup_link()`` end-to-end.
+    """
+    BackupManager(context, node).rewrite_part_links_to_legacy_format(backup_id)
+
+
 @given('file "{path}" was deleted from {node:w} backup #{backup_id:d}')
 @given('file "{path}" was deleted from {node:w} backup "{backup_id:d}"')
 def step_delete_backup_file(context, path, node, backup_id):

--- a/tests/integration/steps/ch_backup_steps.py
+++ b/tests/integration/steps/ch_backup_steps.py
@@ -15,7 +15,7 @@ from hamcrest import (
     starts_with,
 )
 
-from tests.integration.modules.ch_backup import BackupManager
+from tests.integration.modules.ch_backup_cli import BackupManager
 from tests.integration.modules.docker import get_container
 from tests.integration.modules.steps import get_step_data
 

--- a/tests/integration/steps/ch_backup_steps.py
+++ b/tests/integration/steps/ch_backup_steps.py
@@ -74,8 +74,12 @@ def step_backup_metadata_delete(context, node, backup_id):
     BackupManager(context, node).delete_backup_metadata_paths(backup_id, paths)
 
 
-@given("part links of {node:w} backup #{backup_id:d} were rewritten to legacy path format")
-@when("part links of {node:w} backup #{backup_id:d} were rewritten to legacy path format")
+@given(
+    "part links of {node:w} backup #{backup_id:d} were rewritten to legacy path format"
+)
+@when(
+    "part links of {node:w} backup #{backup_id:d} were rewritten to legacy path format"
+)
 def step_rewrite_part_links_to_legacy(context, node, backup_id):
     """
     Simulate a backup created by an older ch-backup version by replacing all

--- a/tests/integration/steps/clickhouse.py
+++ b/tests/integration/steps/clickhouse.py
@@ -7,7 +7,7 @@ from behave import given, then, when
 from hamcrest import assert_that, contains_string, equal_to, has_length
 from tenacity import retry, stop_after_attempt, wait_fixed
 
-from tests.integration.modules.ch_backup import BackupManager
+from tests.integration.modules.ch_backup_cli import BackupManager
 from tests.integration.modules.clickhouse import ClickhouseClient
 from tests.integration.modules.docker import get_container, put_file
 from tests.integration.modules.steps import get_step_data

--- a/tests/integration/steps/common.py
+++ b/tests/integration/steps/common.py
@@ -5,7 +5,7 @@ Common steps.
 import yaml
 from behave import given, when
 
-from tests.integration.modules.ch_backup import get_version
+from tests.integration.modules.ch_backup_cli import get_version
 from tests.integration.modules.docker import copy_between_containers, get_container
 from tests.integration.modules.steps import get_step_data
 from tests.integration.modules.utils import merge

--- a/tests/unit/test_backup_tables.py
+++ b/tests/unit/test_backup_tables.py
@@ -74,7 +74,6 @@ def test_backup_table_skipping_if_metadata_updated_during_backup(
     table_backup = TableBackup()
     backup_meta = BackupMetadata(
         name="20181017T210300",
-        path="ch_backup/20181017T210300",
         version="1.0.100",
         ch_version="19.1.16",
         time_format="%Y-%m-%dT%H:%M:%S%Z",

--- a/tests/unit/test_backup_tables.py
+++ b/tests/unit/test_backup_tables.py
@@ -77,6 +77,8 @@ def test_backup_table_skipping_if_metadata_updated_during_backup(
     table_backup = TableBackup()
     backup_meta = BackupMetadata(
         name="20181017T210300",
+        # DEPRECATED: kept for backward compatibility with older versions.
+        path="ch_backup/20181017T210300",
         version="1.0.100",
         ch_version="19.1.16",
         time_format="%Y-%m-%dT%H:%M:%S%Z",

--- a/tests/unit/test_backup_tables.py
+++ b/tests/unit/test_backup_tables.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass
-from typing import List
-from unittest.mock import Mock, patch
+from typing import List, Optional
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from ch_backup.backup.metadata.backup_metadata import BackupMetadata
+from ch_backup.backup.metadata.part_metadata import PartMetadata
 from ch_backup.backup_context import BackupContext
 from ch_backup.clickhouse.models import Database, Table
 from ch_backup.config import DEFAULT_CONFIG
@@ -120,3 +121,88 @@ def test_backup_table_skipping_if_metadata_updated_during_backup(
     assert len(context.backup_meta.get_tables(db_name)) == backups_expected
     # One call after each table and one after database is backuped
     assert clickhouse_ctl_mock.remove_freezed_data.call_count == 2
+
+
+class TestValidateUploadedParts:
+    """
+    Tests for TableBackup._validate_uploaded_parts.
+    """
+
+    # pylint: disable=protected-access
+
+    _BACKUP_NAME = "20181017T210300"
+
+    def _make_part(self, name: str, link: Optional[str] = None) -> PartMetadata:
+        return PartMetadata(
+            database="db1",
+            table="table1",
+            name=name,
+            checksum="abc123",
+            size=1024,
+            files=["data.bin"],
+            tarball=True,
+            link=link,
+        )
+
+    def _make_context(
+        self, validate: bool, check_returns: bool
+    ) -> tuple[BackupContext, MagicMock]:
+        context = Mock(spec=BackupContext)
+        context.config = {"validate_part_after_upload": validate}
+        context.backup_meta = MagicMock()
+        context.backup_meta.name = self._BACKUP_NAME
+        check_data_part_mock = MagicMock(return_value=check_returns)
+        layout_mock = MagicMock()
+        layout_mock.check_data_part = check_data_part_mock
+        context.backup_layout = layout_mock
+        return context, check_data_part_mock
+
+    def test_validate_disabled_skips_check(self):
+        """When validate_part_after_upload is False, check_data_part is never called."""
+        part = self._make_part("all_1_1_0")
+        context, check_mock = self._make_context(validate=False, check_returns=True)
+
+        TableBackup._validate_uploaded_parts(context, [part])
+
+        check_mock.assert_not_called()
+
+    def test_validate_calls_check_with_backup_name(self):
+        """check_data_part must receive the backup *name* (not a path)."""
+        part = self._make_part("all_1_1_0")
+        context, check_mock = self._make_context(validate=True, check_returns=True)
+
+        TableBackup._validate_uploaded_parts(context, [part])
+
+        check_mock.assert_called_once_with(self._BACKUP_NAME, part)
+
+    def test_validate_raises_on_broken_part(self):
+        """RuntimeError is raised when check_data_part returns False."""
+        part = self._make_part("all_1_1_0")
+        context, _ = self._make_context(validate=True, check_returns=False)
+
+        with pytest.raises(RuntimeError, match="all_1_1_0"):
+            TableBackup._validate_uploaded_parts(context, [part])
+
+    def test_validate_deduplicated_part_uses_backup_name(self):
+        """
+        For a deduplicated part (link set to a source backup name),
+        _validate_uploaded_parts still passes the *current* backup name to
+        check_data_part — the layout itself resolves the link internally.
+        """
+        source_backup = "20181010T120000"
+        part = self._make_part("all_1_1_0", link=source_backup)
+        context, check_mock = self._make_context(validate=True, check_returns=True)
+
+        TableBackup._validate_uploaded_parts(context, [part])
+
+        check_mock.assert_called_once_with(self._BACKUP_NAME, part)
+
+    def test_validate_all_parts_checked_before_raising(self):
+        """All invalid parts are collected before RuntimeError is raised."""
+        parts = [self._make_part(f"all_{i}_1_0") for i in range(3)]
+        context, check_mock = self._make_context(validate=True, check_returns=False)
+
+        with pytest.raises(RuntimeError):
+            TableBackup._validate_uploaded_parts(context, parts)
+
+        assert check_mock.call_count == 3

--- a/tests/unit/test_backup_tables.py
+++ b/tests/unit/test_backup_tables.py
@@ -4,8 +4,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from ch_backup.backup.metadata.backup_metadata import BackupMetadata
-from ch_backup.backup.metadata.part_metadata import PartMetadata
+from ch_backup.backup.metadata import BackupMetadata, PartMetadata
 from ch_backup.backup_context import BackupContext
 from ch_backup.clickhouse.models import Database, Table
 from ch_backup.config import DEFAULT_CONFIG

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -84,7 +84,10 @@ class TestBackupMetadata:
             hostname="clickhouse01.test_net_711",
         )
 
+        dump = backup.dump()
         assert backup.dump_json().find(" ") == -1
+        # Deprecated `path` field must not be emitted anymore
+        assert "path" not in dump["meta"]
 
     @pytest.mark.parametrize(
         "access_control",
@@ -265,6 +268,9 @@ class TestPartMetadata:
         "tarball": False,
         "disk_name": "default",
         "encrypted": True,
+        "database": "test_db",
+        "table": "test_table",
+        "name": "20181017T210300",
     }
 
     @pytest.mark.parametrize(
@@ -276,6 +282,8 @@ class TestPartMetadata:
             ("ch_backup/20181017T210300", "20181017T210300"),
             # Old format: absolute path.
             ("/srv/backups/20181017T210300", "20181017T210300"),
+            # Nested path with trailing slash — must reduce to last component.
+            ("/srv/backups/daily/20181017T210300/", "20181017T210300"),
             # No link (non-deduplicated part).
             (None, None),
             # Empty string treated as no link.
@@ -287,7 +295,17 @@ class TestPartMetadata:
         PartMetadata.load() must normalise the ``link`` field to a plain
         backup name regardless of whether it was stored as a full path
         (old format) or already as a name (new format).
+
+        Also asserts that non-link fields are preserved unchanged.
         """
         raw = {**self._BASE_RAW, "link": raw_link}
         part = PartMetadata.load("db1", "table1", "part1", raw)
+
+        # link normalization
         assert part.link == expected_link
+
+        # non-link fields must be preserved
+        assert part.database == "db1"
+        assert part.table == "table1"
+        assert part.name == "part1"
+        assert part.files == raw["files"]

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -12,8 +12,9 @@ from ch_backup.backup.metadata import (
     BackupMetadata,
     BackupState,
     BackupStorageFormat,
+    PartMetadata,
+    normalize_backup_link,
 )
-from ch_backup.backup.metadata.part_metadata import PartMetadata, normalize_backup_link
 
 
 class TestBackupMetadata:

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -13,7 +13,7 @@ from ch_backup.backup.metadata import (
     BackupState,
     BackupStorageFormat,
 )
-from ch_backup.backup.metadata.part_metadata import PartMetadata
+from ch_backup.backup.metadata.part_metadata import PartMetadata, normalize_backup_link
 
 
 class TestBackupMetadata:
@@ -309,3 +309,76 @@ class TestPartMetadata:
         assert part.table == "table1"
         assert part.name == "part1"
         assert part.files == raw["files"]
+
+
+class TestNormalizeBackupLink:
+    """
+    Tests for the normalize_backup_link() module-level helper.
+    """
+
+    @pytest.mark.parametrize(
+        ("raw_link", "expected"),
+        [
+            # New format: plain backup name — returned as-is.
+            ("20181017T210300", "20181017T210300"),
+            # Old format: relative path with path_root prefix.
+            ("ch_backup/20181017T210300", "20181017T210300"),
+            # Old format: absolute path.
+            ("/srv/backups/20181017T210300", "20181017T210300"),
+            # Nested path with trailing slash — must reduce to last component.
+            ("/srv/backups/daily/20181017T210300/", "20181017T210300"),
+            # None → None.
+            (None, None),
+            # Empty string → None.
+            ("", None),
+        ],
+    )
+    def test_normalize_backup_link(self, raw_link, expected):
+        """
+        normalize_backup_link() must return a plain backup name for both
+        old full-path and new name-only formats, and None for falsy input.
+        """
+        assert normalize_backup_link(raw_link) == expected
+
+
+class TestBackupMetadataLegacyPath:
+    """
+    Backward-compatibility tests for the deprecated ``meta.path`` field.
+    """
+
+    def test_load_json_accepts_legacy_path_field(self):
+        """
+        BackupMetadata.load_json() must succeed when the JSON contains the
+        deprecated ``meta.path`` field (present in old backups) and must
+        still populate all other fields correctly.
+
+        Regression test: ensure we do not break reading old backup metadata.
+        """
+        metadata = {
+            "meta": {
+                "name": "20181017T210300",
+                # Legacy field — must be silently ignored during load.
+                "path": "ch_backup/20181017T210300",
+                "time_format": "%Y-%m-%d %H:%M:%S %z",
+                "bytes": 0,
+                "real_bytes": 0,
+                "hostname": "clickhouse01.test_net_711",
+                "version": "1.0.100",
+                "ch_version": "19.1.16",
+                "labels": None,
+                "state": "created",
+                "start_time": "2018-10-18 00:03:00 +0300",
+                "end_time": "2018-10-18 00:04:00 +0300",
+            },
+            "databases": [],
+        }
+
+        backup = BackupMetadata.load_json(json.dumps(metadata))
+
+        assert backup.name == "20181017T210300"
+        assert backup.state == BackupState.CREATED
+        assert backup.hostname == "clickhouse01.test_net_711"
+        assert backup.version == "1.0.100"
+        assert backup.ch_version == "19.1.16"
+        # Legacy field must be silently ignored — must not appear in serialized output.
+        assert "path" not in json.loads(backup.dump_json())["meta"]

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -146,6 +146,43 @@ class TestBackupMetadata:
         }
         assert acl.backup_format == BackupStorageFormat.PLAIN
 
+    def test_load_json_accepts_legacy_path_field(self):
+        """
+        BackupMetadata.load_json() must succeed when the JSON contains the
+        deprecated ``meta.path`` field (present in old backups) and must
+        still populate all other fields correctly.
+
+        Regression test: ensure we do not break reading old backup metadata.
+        """
+        metadata = {
+            "meta": {
+                "name": "20181017T210300",
+                # Legacy field — must be silently ignored during load.
+                "path": "ch_backup/20181017T210300",
+                "time_format": "%Y-%m-%d %H:%M:%S %z",
+                "bytes": 0,
+                "real_bytes": 0,
+                "hostname": "clickhouse01.test_net_711",
+                "version": "1.0.100",
+                "ch_version": "19.1.16",
+                "labels": None,
+                "state": "created",
+                "start_time": "2018-10-18 00:03:00 +0300",
+                "end_time": "2018-10-18 00:04:00 +0300",
+            },
+            "databases": [],
+        }
+
+        backup = BackupMetadata.load_json(json.dumps(metadata))
+
+        assert backup.name == "20181017T210300"
+        assert backup.state == BackupState.CREATED
+        assert backup.hostname == "clickhouse01.test_net_711"
+        assert backup.version == "1.0.100"
+        assert backup.ch_version == "19.1.16"
+        # Legacy field must be silently ignored — must not appear in serialized output.
+        assert "path" not in json.loads(backup.dump_json())["meta"]
+
 
 class TestAccessControlMetadata:
     @pytest.mark.parametrize(
@@ -339,46 +376,3 @@ class TestNormalizeBackupLink:
         old full-path and new name-only formats, and None for falsy input.
         """
         assert normalize_backup_link(raw_link) == expected
-
-
-class TestBackupMetadataLegacyPath:
-    """
-    Backward-compatibility tests for the deprecated ``meta.path`` field.
-    """
-
-    def test_load_json_accepts_legacy_path_field(self):
-        """
-        BackupMetadata.load_json() must succeed when the JSON contains the
-        deprecated ``meta.path`` field (present in old backups) and must
-        still populate all other fields correctly.
-
-        Regression test: ensure we do not break reading old backup metadata.
-        """
-        metadata = {
-            "meta": {
-                "name": "20181017T210300",
-                # Legacy field — must be silently ignored during load.
-                "path": "ch_backup/20181017T210300",
-                "time_format": "%Y-%m-%d %H:%M:%S %z",
-                "bytes": 0,
-                "real_bytes": 0,
-                "hostname": "clickhouse01.test_net_711",
-                "version": "1.0.100",
-                "ch_version": "19.1.16",
-                "labels": None,
-                "state": "created",
-                "start_time": "2018-10-18 00:03:00 +0300",
-                "end_time": "2018-10-18 00:04:00 +0300",
-            },
-            "databases": [],
-        }
-
-        backup = BackupMetadata.load_json(json.dumps(metadata))
-
-        assert backup.name == "20181017T210300"
-        assert backup.state == BackupState.CREATED
-        assert backup.hostname == "clickhouse01.test_net_711"
-        assert backup.version == "1.0.100"
-        assert backup.ch_version == "19.1.16"
-        # Legacy field must be silently ignored — must not appear in serialized output.
-        assert "path" not in json.loads(backup.dump_json())["meta"]

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -13,6 +13,7 @@ from ch_backup.backup.metadata import (
     BackupState,
     BackupStorageFormat,
 )
+from ch_backup.backup.metadata.part_metadata import PartMetadata
 
 
 class TestBackupMetadata:
@@ -42,7 +43,6 @@ class TestBackupMetadata:
 
         meta = {
             "name": "20181017T210300",
-            "path": "ch_backup/20181017T210300",
             "time_format": "%Y-%m-%d %H:%M:%S %z",
             "bytes": 0,
             "real_bytes": 0,
@@ -59,7 +59,6 @@ class TestBackupMetadata:
 
         backup = BackupMetadata.load_json(json.dumps(metadata))
         assert backup.name == meta["name"]
-        assert backup.path == meta["path"]
         assert backup.state == BackupState(meta["state"])
         time_format = meta["time_format"]
         assert backup.time_format == time_format
@@ -79,7 +78,6 @@ class TestBackupMetadata:
     def test_dump_is_compact(self):
         backup = BackupMetadata(
             name="20181017T210300",
-            path="ch_backup/20181017T210300",
             version="1.0.100",
             ch_version="19.1.16",
             time_format="%Y-%m-%dT%H:%M:%S%Z",
@@ -118,7 +116,6 @@ class TestBackupMetadata:
         metadata = {
             "meta": {
                 "name": "20181017T210300",
-                "path": "ch_backup/20181017T210300",
                 "time_format": "%Y-%m-%d %H:%M:%S %z",
                 "bytes": 0,
                 "real_bytes": 0,
@@ -254,3 +251,43 @@ class TestAccessControlMetadata:
             },
             "backup_format": "tar",
         }
+
+
+class TestPartMetadata:
+    """
+    Tests for PartMetadata.
+    """
+
+    _BASE_RAW = {
+        "checksum": "abc123",
+        "bytes": 1024,
+        "files": ["data.bin"],
+        "tarball": False,
+        "disk_name": "default",
+        "encrypted": True,
+    }
+
+    @pytest.mark.parametrize(
+        ("raw_link", "expected_link"),
+        [
+            # New format: plain backup name — returned as-is.
+            ("20181017T210300", "20181017T210300"),
+            # Old format: full path with path_root prefix.
+            ("ch_backup/20181017T210300", "20181017T210300"),
+            # Old format: absolute path.
+            ("/srv/backups/20181017T210300", "20181017T210300"),
+            # No link (non-deduplicated part).
+            (None, None),
+            # Empty string treated as no link.
+            ("", None),
+        ],
+    )
+    def test_load_link_normalization(self, raw_link, expected_link):
+        """
+        PartMetadata.load() must normalise the ``link`` field to a plain
+        backup name regardless of whether it was stored as a full path
+        (old format) or already as a name (new format).
+        """
+        raw = {**self._BASE_RAW, "link": raw_link}
+        part = PartMetadata.load("db1", "table1", "part1", raw)
+        assert part.link == expected_link

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -79,6 +79,7 @@ class TestBackupMetadata:
     def test_dump_is_compact(self):
         backup = BackupMetadata(
             name="20181017T210300",
+            path="ch_backup/20181017T210300",
             version="1.0.100",
             ch_version="19.1.16",
             time_format="%Y-%m-%dT%H:%M:%S%Z",
@@ -87,8 +88,9 @@ class TestBackupMetadata:
 
         dump = backup.dump()
         assert backup.dump_json().find(" ") == -1
-        # Deprecated `path` field must not be emitted anymore
-        assert "path" not in dump["meta"]
+        # Deprecated `path` field is still emitted for backward compatibility
+        # with older ch-backup versions that read it.
+        assert dump["meta"]["path"] == "ch_backup/20181017T210300"
 
     @pytest.mark.parametrize(
         "access_control",
@@ -158,7 +160,9 @@ class TestBackupMetadata:
         metadata = {
             "meta": {
                 "name": "20181017T210300",
-                # Legacy field — must be silently ignored during load.
+                # DEPRECATED legacy field — preserved on load and re-emitted
+                # on dump for backward compatibility with older ch-backup
+                # versions.
                 "path": "ch_backup/20181017T210300",
                 "time_format": "%Y-%m-%d %H:%M:%S %z",
                 "bytes": 0,
@@ -181,8 +185,13 @@ class TestBackupMetadata:
         assert backup.hostname == "clickhouse01.test_net_711"
         assert backup.version == "1.0.100"
         assert backup.ch_version == "19.1.16"
-        # Legacy field must be silently ignored — must not appear in serialized output.
-        assert "path" not in json.loads(backup.dump_json())["meta"]
+        # Legacy ``path`` is preserved through the load/dump round-trip
+        # (deprecated, but still required for older ch-backup versions).
+        assert backup.path == "ch_backup/20181017T210300"
+        assert (
+            json.loads(backup.dump_json())["meta"]["path"]
+            == "ch_backup/20181017T210300"
+        )
 
 
 class TestAccessControlMetadata:

--- a/tests/unit/test_upload_part_observer.py
+++ b/tests/unit/test_upload_part_observer.py
@@ -2,9 +2,7 @@ import copy
 from typing import List
 from unittest.mock import Mock, patch
 
-from ch_backup.backup.metadata.backup_metadata import BackupMetadata
-from ch_backup.backup.metadata.part_metadata import PartMetadata
-from ch_backup.backup.metadata.table_metadata import TableMetadata
+from ch_backup.backup.metadata import BackupMetadata, PartMetadata, TableMetadata
 from ch_backup.backup_context import BackupContext
 from ch_backup.clickhouse.models import Database
 from ch_backup.logic.upload_part_observer import UploadPartObserver

--- a/tests/unit/test_upload_part_observer.py
+++ b/tests/unit/test_upload_part_observer.py
@@ -17,7 +17,6 @@ ENGINE = "MergeTree"
 BACKUP_NAME = "TestBackup"
 BACKUP_META = BackupMetadata(
     name=BACKUP_NAME,
-    path=f"ch_backup/{BACKUP_NAME}",
     version="1.0.100",
     ch_version="19.1.16",
     time_format="%Y-%m-%dT%H:%M:%S%Z",

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -114,6 +114,9 @@ def backup_metadata(
         {
             "meta": {
                 "name": name,
+                # DEPRECATED: the ``path`` field is kept for backward
+                # compatibility with older ch-backup versions.
+                "path": f"ch_backup/{name}",
                 "hostname": hostname,
                 "state": state,
                 "start_time": start_time,

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -114,7 +114,6 @@ def backup_metadata(
         {
             "meta": {
                 "name": name,
-                "path": f"ch_backup/{name}",
                 "hostname": hostname,
                 "state": state,
                 "start_time": start_time,


### PR DESCRIPTION
## Summary by Sourcery

Normalize backup metadata to use backup names and dynamically computed paths instead of storing full backup paths, and update deduplication, layout operations, and validation logic accordingly.

Bug Fixes:
- Ensure part validation and deduplication resolve deduplicated parts via backup names so that old backups with path-based links continue to work with new config-driven paths.

Enhancements:
- Remove the deprecated backup path field from BackupMetadata and derive storage paths from configured path_root and backup name across layout and integration helpers.
- Normalize PartMetadata.link to always store a plain backup name, supporting migration from legacy path-based formats.
- Refine deduplication metadata to track source backups by name and improve logging messages for reused or invalid parts.

Tests:
- Extend unit tests for BackupMetadata and PartMetadata to cover removal of the deprecated path field and link normalization semantics.
- Add unit tests for TableBackup._validate_uploaded_parts to verify its behavior with configuration flags, deduplicated parts, and error aggregation.
- Adjust integration tests to work with dynamic backup paths from ch-backup configuration and to handle both legacy and new link formats when enumerating backup files.