### PR TITLE
Fix TABLE_WAS_NOT_DROPPED by falling back to direct ZK deletion when SYSTEM DROP REPLICA fails

### DIFF
--- a/ch_backup/clickhouse/metadata_cleaner.py
+++ b/ch_backup/clickhouse/metadata_cleaner.py
@@ -5,9 +5,10 @@ Zookeeper metadata cleaner for clickhouse.
 import copy
 import os
 from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-from kazoo.exceptions import NoNodeError
+from kazoo.exceptions import KazooException, NoNodeError
 
 from ch_backup import logging
 from ch_backup.clickhouse.client import ClickhouseError
@@ -20,6 +21,41 @@ from ch_backup.util import (
     replace_macros,
 )
 from ch_backup.zookeeper.zookeeper import ZookeeperCTL
+
+
+@dataclass
+class _TableCleanupTask:
+    """Holds a scheduled cleanup future together with its ZooKeeper path."""
+
+    future: Future
+    zk_path: str
+
+
+def _is_table_was_not_dropped_error(error: ClickhouseError) -> bool:
+    """
+    Detect ClickHouse TABLE_WAS_NOT_DROPPED errors.
+
+    Prefer using structured attributes (e.g., error.code or error.type) if available.
+    Message-based matching is kept as a fallback to avoid tight coupling to wording.
+    """
+    # Structured detection (extend this if ClickHouse exposes specific codes/types)
+    code = getattr(error, "code", None)
+    if code is not None:
+        # TODO: replace with the concrete TABLE_WAS_NOT_DROPPED code when known.
+        table_was_not_dropped_codes: set = set()
+        if code in table_was_not_dropped_codes:
+            return True
+
+    # Fallback to message-based matching
+    message = str(error)
+    return "TABLE_WAS_NOT_DROPPED" in message or "There is a local table" in message
+
+
+def _is_not_table_path_error(error: ClickhouseError) -> bool:
+    """
+    Detect ClickHouse errors indicating the ZK path does not look like a table path.
+    """
+    return "does not look like a table path" in str(error)
 
 
 def select_replica_drop(replica_name: Optional[str], macros: Dict) -> str:
@@ -61,52 +97,39 @@ class MetadataCleaner:
         """
         replicated_table_paths = get_table_zookeeper_paths(replicated_tables)
         # Key is "{table_name}/{replica}" to correctly handle multiple replicas per table.
-        tasks: Dict[str, Future] = {}
-        zk_paths: Dict[str, str] = {}
+        cleanup_tasks: Dict[str, _TableCleanupTask] = {}
         for table, table_path in replicated_table_paths:
-            self._schedule_table_replicas_cleanup(table, table_path, tasks, zk_paths)
+            self._schedule_table_replicas_cleanup(table, table_path, cleanup_tasks)
 
-        for task_key, future in tasks.items():
+        for task_key, task in cleanup_tasks.items():
             full_table_name = task_key.rsplit("/", 1)[0]
             try:
-                future.result()
+                task.future.result()
                 logging.debug(
                     "Successful zk metadata cleanup for table {}", full_table_name
                 )
             except ClickhouseError as ch_error:
-                error_message = str(ch_error)
-                # Check if it's the TABLE_WAS_NOT_DROPPED error
-                if (
-                    "TABLE_WAS_NOT_DROPPED" in error_message
-                    or "There is a local table" in error_message
-                ):
+                if _is_table_was_not_dropped_error(ch_error):
                     logging.warning(
-                        "System drop replica failed with TABLE_WAS_NOT_DROPPED for table {}. "
+                        "System drop replica failed for table {} because a local table "
+                        "still exists (TABLE_WAS_NOT_DROPPED or 'There is a local table'). "
                         "Falling back to direct ZK node deletion.",
                         full_table_name,
                     )
-                    # Fallback to direct ZK deletion
-                    zk_path = zk_paths.get(task_key)
-                    if zk_path is None:
-                        logging.error(
-                            "Cannot perform fallback ZK deletion for table {}: ZK path not found",
-                            full_table_name,
-                        )
-                        raise
                     try:
-                        self._delete_replica_zk_nodes(zk_path)
+                        self._delete_replica_zk_nodes(task.zk_path)
                         logging.debug(
                             "Successful fallback ZK metadata cleanup for table {}",
                             full_table_name,
                         )
-                    except Exception as fallback_error:
+                    except KazooException as fallback_error:
                         logging.error(
                             "Fallback ZK deletion failed for table {}: {}",
                             full_table_name,
                             repr(fallback_error),
                         )
                         raise
-                elif "does not look like a table path" in error_message:
+                elif _is_not_table_path_error(ch_error):
                     logging.warning(
                         "System drop replica failed with: {}\n Will ignore it, probably different configuration for zookeeper or tables schema.",
                         repr(ch_error),
@@ -118,12 +141,11 @@ class MetadataCleaner:
         self,
         table: Table,
         table_path: str,
-        tasks: Dict[str, Future],
-        zk_paths: Dict[str, str],
+        cleanup_tasks: Dict[str, _TableCleanupTask],
     ) -> None:
         """
         Schedule ZK metadata cleanup tasks for all replicas of a single table.
-        Populates tasks and zk_paths dicts with per-replica entries.
+        Populates cleanup_tasks dict with per-replica entries.
         """
         table_macros = copy.copy(self._macros)
         macros_to_override = dict(
@@ -174,11 +196,13 @@ class MetadataCleaner:
                     replica,
                 )
                 task_key = f"{full_table_name}/{replica}"
-                zk_paths[task_key] = full_table_zk_path
-                tasks[task_key] = self._exec_pool.submit(
-                    self._ch_ctl.system_drop_replica,
-                    replica,
-                    path_resolved,
+                cleanup_tasks[task_key] = _TableCleanupTask(
+                    future=self._exec_pool.submit(
+                        self._ch_ctl.system_drop_replica,
+                        replica,
+                        path_resolved,
+                    ),
+                    zk_path=full_table_zk_path,
                 )
 
     def _delete_replica_zk_nodes(self, zk_path: str) -> None:

--- a/ch_backup/clickhouse/metadata_cleaner.py
+++ b/ch_backup/clickhouse/metadata_cleaner.py
@@ -60,76 +60,140 @@ class MetadataCleaner:
         Remove replica tables metadata from zookeeper.
         """
         replicated_table_paths = get_table_zookeeper_paths(replicated_tables)
+        # Key is "{table_name}/{replica}" to correctly handle multiple replicas per table.
         tasks: Dict[str, Future] = {}
+        zk_paths: Dict[str, str] = {}
         for table, table_path in replicated_table_paths:
-            table_macros = copy.copy(self._macros)
-            macros_to_override = dict(
-                database=table.database, table=table.name, uuid=table.uuid
-            )
-            table_macros.update(macros_to_override)
+            self._schedule_table_replicas_cleanup(table, table_path, tasks, zk_paths)
 
-            path_resolved = os.path.abspath(replace_macros(table_path, table_macros))
-            full_table_name = f"{table.database}.{table.name}"
-            replicas_to_drop = (
-                [self._replica_to_drop]
-                if self._replica_to_drop
-                else self._list_replicas(path_resolved)
-            )
-
-            logging.debug(
-                f'Will search for existing ZooKeeper metadata for "{full_table_name}" at "{path_resolved}"'
-            )
-
-            with self._zk_ctl.zk_client as zk_client:
-                for replica in replicas_to_drop:
-                    # Both paths are already abs.
-                    full_table_zk_path = (
-                        self._zk_ctl.zk_root_path  # type: ignore
-                        + path_resolved
-                        + "/replicas/"
-                        + replica
-                    )
-                    if not zk_client.exists(full_table_zk_path):
-                        logging.debug(
-                            "There are no nodes for the replicated table {} with zk path {}",
-                            full_table_name,
-                            full_table_zk_path,
-                        )
-                        return
-
-                    # We are sure that we want to  drop the table from zk.
-                    # To force it we will remove it active flag.
-                    active_flag_path = os.path.join(full_table_zk_path, "is_active")
-                    try:
-                        zk_client.delete(active_flag_path)
-                    except NoNodeError:
-                        pass
-
-                    logging.debug(
-                        "Scheduling metadata cleanup for table {}, replica to clean: {}",
-                        full_table_name,
-                        replica,
-                    )
-                    tasks[full_table_name] = self._exec_pool.submit(
-                        self._ch_ctl.system_drop_replica,
-                        replica,
-                        path_resolved,
-                    )
-
-        for full_table_name, future in tasks.items():
+        for task_key, future in tasks.items():
+            full_table_name = task_key.rsplit("/", 1)[0]
             try:
                 future.result()
                 logging.debug(
                     "Successful zk metadata cleanup for table {}", full_table_name
                 )
             except ClickhouseError as ch_error:
-                if "does not look like a table path" in str(ch_error):
+                error_message = str(ch_error)
+                # Check if it's the TABLE_WAS_NOT_DROPPED error
+                if (
+                    "TABLE_WAS_NOT_DROPPED" in error_message
+                    or "There is a local table" in error_message
+                ):
+                    logging.warning(
+                        "System drop replica failed with TABLE_WAS_NOT_DROPPED for table {}. "
+                        "Falling back to direct ZK node deletion.",
+                        full_table_name,
+                    )
+                    # Fallback to direct ZK deletion
+                    zk_path = zk_paths.get(task_key)
+                    if zk_path is None:
+                        logging.error(
+                            "Cannot perform fallback ZK deletion for table {}: ZK path not found",
+                            full_table_name,
+                        )
+                        raise
+                    try:
+                        self._delete_replica_zk_nodes(zk_path)
+                        logging.debug(
+                            "Successful fallback ZK metadata cleanup for table {}",
+                            full_table_name,
+                        )
+                    except Exception as fallback_error:
+                        logging.error(
+                            "Fallback ZK deletion failed for table {}: {}",
+                            full_table_name,
+                            repr(fallback_error),
+                        )
+                        raise
+                elif "does not look like a table path" in error_message:
                     logging.warning(
                         "System drop replica failed with: {}\n Will ignore it, probably different configuration for zookeeper or tables schema.",
                         repr(ch_error),
                     )
                 else:
                     raise
+
+    def _schedule_table_replicas_cleanup(
+        self,
+        table: Table,
+        table_path: str,
+        tasks: Dict[str, Future],
+        zk_paths: Dict[str, str],
+    ) -> None:
+        """
+        Schedule ZK metadata cleanup tasks for all replicas of a single table.
+        Populates tasks and zk_paths dicts with per-replica entries.
+        """
+        table_macros = copy.copy(self._macros)
+        macros_to_override = dict(
+            database=table.database, table=table.name, uuid=table.uuid
+        )
+        table_macros.update(macros_to_override)
+
+        path_resolved = os.path.abspath(replace_macros(table_path, table_macros))
+        full_table_name = f"{table.database}.{table.name}"
+        replicas_to_drop = (
+            [self._replica_to_drop]
+            if self._replica_to_drop
+            else self._list_replicas(path_resolved)
+        )
+
+        logging.debug(
+            f'Will search for existing ZooKeeper metadata for "{full_table_name}" at "{path_resolved}"'
+        )
+
+        with self._zk_ctl.zk_client as zk_client:
+            for replica in replicas_to_drop:
+                # Both paths are already abs.
+                full_table_zk_path = (
+                    self._zk_ctl.zk_root_path  # type: ignore
+                    + path_resolved
+                    + "/replicas/"
+                    + replica
+                )
+                if not zk_client.exists(full_table_zk_path):
+                    logging.debug(
+                        "There are no nodes for the replicated table {} with zk path {}",
+                        full_table_name,
+                        full_table_zk_path,
+                    )
+                    continue
+
+                # We are sure that we want to  drop the table from zk.
+                # To force it we will remove it active flag.
+                active_flag_path = os.path.join(full_table_zk_path, "is_active")
+                try:
+                    zk_client.delete(active_flag_path)
+                except NoNodeError:
+                    pass
+
+                logging.debug(
+                    "Scheduling metadata cleanup for table {}, replica to clean: {}",
+                    full_table_name,
+                    replica,
+                )
+                task_key = f"{full_table_name}/{replica}"
+                zk_paths[task_key] = full_table_zk_path
+                tasks[task_key] = self._exec_pool.submit(
+                    self._ch_ctl.system_drop_replica,
+                    replica,
+                    path_resolved,
+                )
+
+    def _delete_replica_zk_nodes(self, zk_path: str) -> None:
+        """
+        Delete replica metadata nodes directly from ZooKeeper.
+        This is a fallback method when SYSTEM DROP REPLICA fails.
+        """
+        with self._zk_ctl.zk_client as zk_client:
+            try:
+                # Recursively delete the replica node and all its children
+                zk_client.delete(zk_path, recursive=True)
+                logging.debug("Deleted ZK node {} recursively", zk_path)
+            except NoNodeError:
+                # Node already deleted, it's fine
+                logging.debug("ZK node {} was already deleted", zk_path)
 
     def _list_replicas(self, zk_path: str) -> List[str]:
         replicas_path = (

--- a/tests/integration/features/backup_replicated.feature
+++ b/tests/integration/features/backup_replicated.feature
@@ -1070,6 +1070,9 @@ Feature: Backup replicated merge tree table
   ## Setup: table exists on clickhouse02 with ZK replica node present but corrupted (empty),
   ## so the table is in readonly state. SYSTEM DROP REPLICA FROM ZKPATH fails because the table
   ## exists locally, triggering the ZK client fallback.
+  ## Note: In CH < 23.3, SYSTEM RESTART REPLICA with a corrupted (empty) ZK replica node crashes
+  ## instead of transitioning the table to is_readonly=1, so this scenario requires CH >= 23.9.
+  @require_version_23.3
   Scenario: Restore readonly table when SYSTEM DROP REPLICA fails with TABLE_WAS_NOT_DROPPED
     Given we have executed queries on clickhouse01
     """

--- a/tests/integration/features/backup_replicated.feature
+++ b/tests/integration/features/backup_replicated.feature
@@ -1064,3 +1064,77 @@ Feature: Backup replicated merge tree table
     """
     20
     """
+
+  ## Reproduces TABLE_WAS_NOT_DROPPED (error 305): ClickHouse refuses SYSTEM DROP REPLICA FROM ZKPATH
+  ## when the table exists locally. The fix falls back to direct ZK node deletion via kazoo client.
+  ## Setup: table exists on clickhouse02 with ZK replica node present but corrupted (empty),
+  ## so the table is in readonly state. SYSTEM DROP REPLICA FROM ZKPATH fails because the table
+  ## exists locally, triggering the ZK client fallback.
+  Scenario: Restore readonly table when SYSTEM DROP REPLICA fails with TABLE_WAS_NOT_DROPPED
+    Given we have executed queries on clickhouse01
+    """
+    CREATE DATABASE test_db;
+    CREATE TABLE test_db.table_01 (
+        EventDate DateTime,
+        CounterID UInt32,
+        UserID UInt32
+    )
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/shard_01/test_db.table_01', '{replica}')
+    PARTITION BY CounterID % 10
+    ORDER BY (CounterID, EventDate, intHash32(UserID))
+    SAMPLE BY intHash32(UserID);
+    INSERT INTO test_db.table_01 SELECT now(), number, rand() FROM system.numbers LIMIT 10
+    """
+    When we create clickhouse01 clickhouse backup
+    Then we got the following backups on clickhouse01
+      | num | state   | data_count | link_count |
+      | 0   | created | 10         | 0          |
+    Given we have executed queries on clickhouse02
+    """
+    CREATE DATABASE test_db;
+    CREATE TABLE test_db.table_01 (
+        EventDate DateTime,
+        CounterID UInt32,
+        UserID UInt32
+    )
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/shard_01/test_db.table_01', '{replica}')
+    PARTITION BY CounterID % 10
+    ORDER BY (CounterID, EventDate, intHash32(UserID))
+    SAMPLE BY intHash32(UserID);
+    """
+    ## Delete the replica ZK node entirely, then recreate it as an empty node.
+    ## This makes the table go readonly (ZK node exists but is corrupted/empty),
+    ## while keeping the local table — exactly the condition that triggers TABLE_WAS_NOT_DROPPED.
+    Given on zookeeper01 we delete /clickhouse02/clickhouse/tables/shard_01/test_db.table_01/replicas/clickhouse02
+    When on zookeeper01 we create /clickhouse02/clickhouse/tables/shard_01/test_db.table_01/replicas/clickhouse02
+    Given we have executed queries on clickhouse02
+    """
+    SYSTEM RESTART REPLICA test_db.table_01
+    """
+    When we execute query on clickhouse02
+    """
+    SELECT is_readonly FROM system.replicas WHERE table = 'table_01' and database = 'test_db'
+    """
+    Then we get response
+    """
+    1
+    """
+    When we restore clickhouse backup #0 to clickhouse02
+    Then clickhouse02 has same schema as clickhouse01
+    Then we got same clickhouse data at clickhouse01 clickhouse02
+    When we execute query on clickhouse02
+    """
+    SELECT is_readonly FROM system.replicas WHERE table = 'table_01' and database = 'test_db'
+    """
+    Then we get response
+    """
+    0
+    """
+    When we execute query on clickhouse02
+    """
+    SELECT count() FROM test_db.table_01
+    """
+    Then we get response
+    """
+    10
+    """


### PR DESCRIPTION
## Summary by Sourcery

Handle failures of SYSTEM DROP REPLICA during metadata cleanup by falling back to direct ZooKeeper deletion and improve per-replica cleanup scheduling.

Bug Fixes:
- Ensure replicated table metadata is cleaned up even when SYSTEM DROP REPLICA fails with TABLE_WAS_NOT_DROPPED or local table still exists.

Enhancements:
- Refactor replicated table metadata cleanup to schedule per-replica tasks and track their ZooKeeper paths for better error handling and observability.

Tests:
- Add an integration scenario that reproduces TABLE_WAS_NOT_DROPPED for a readonly replica and verifies successful backup restore and metadata cleanup via the new ZooKeeper deletion fallback.