### PR TITLE
[fix] Support default configuration

### DIFF
--- a/ch_backup/clickhouse/disks.py
+++ b/ch_backup/clickhouse/disks.py
@@ -74,7 +74,9 @@ class ClickHouseTemporaryDisks:
         self._ch_availible_disks: Dict[str, Disk] = {}
 
     def __enter__(self):
-        self._disks = self._ch_config.config.get("storage_configuration", {}).get("disks", {})
+        self._disks = self._ch_config.config.get("storage_configuration", {}).get(
+            "disks", {}
+        )
         for disk_name in self._backup_meta.cloud_storage.disks:
             self._create_temporary_disk(
                 self._backup_meta,

--- a/ch_backup/clickhouse/disks.py
+++ b/ch_backup/clickhouse/disks.py
@@ -74,7 +74,9 @@ class ClickHouseTemporaryDisks:
         self._ch_availible_disks: Dict[str, Disk] = {}
 
     def __enter__(self):
-        self._disks = self._ch_config.config["storage_configuration"]["disks"]
+        self._disks = (self._ch_config.config.get("storage_configuration") or {}).get(
+            "disks"
+        ) or {}
         for disk_name in self._backup_meta.cloud_storage.disks:
             self._create_temporary_disk(
                 self._backup_meta,
@@ -141,9 +143,13 @@ class ClickHouseTemporaryDisks:
     ) -> None:
         tmp_disk_name = _get_tmp_disk_name(disk_name)
         logging.debug(f"Creating tmp disk {tmp_disk_name}")
-        disk_config = copy.copy(
-            self._ch_config.config["storage_configuration"]["disks"][disk_name]
-        )
+        if disk_name not in self._disks:
+            raise ClickHouseDisksException(
+                f'Disk "{disk_name}" is present in backup cloud storage metadata'
+                f" but is missing from ClickHouse storage_configuration."
+                f" Add the disk to the ClickHouse configuration and retry."
+            )
+        disk_config = copy.copy(self._disks[disk_name])
 
         endpoint = urlparse(disk_config["endpoint"])
         endpoint_netloc = source_endpoint or endpoint.netloc
@@ -151,9 +157,7 @@ class ClickHouseTemporaryDisks:
         tmp_disk_enpoint = os.path.join(
             f"{endpoint.scheme}://{endpoint_netloc}", source_bucket, source_path, ""
         )
-        orig_disk_enpoint = self._ch_config.config["storage_configuration"]["disks"][
-            disk_name
-        ]["endpoint"]
+        orig_disk_enpoint = self._disks[disk_name]["endpoint"]
 
         if self._use_local_copy and not is_equal_s3_endpoints(
             tmp_disk_enpoint, orig_disk_enpoint

--- a/ch_backup/clickhouse/disks.py
+++ b/ch_backup/clickhouse/disks.py
@@ -154,20 +154,20 @@ class ClickHouseTemporaryDisks:
         endpoint = urlparse(disk_config["endpoint"])
         endpoint_netloc = source_endpoint or endpoint.netloc
 
-        tmp_disk_enpoint = os.path.join(
+        tmp_disk_endpoint = os.path.join(
             f"{endpoint.scheme}://{endpoint_netloc}", source_bucket, source_path, ""
         )
-        orig_disk_enpoint = self._disks[disk_name]["endpoint"]
+        orig_disk_endpoint = self._disks[disk_name]["endpoint"]
 
         if self._use_local_copy and not is_equal_s3_endpoints(
-            tmp_disk_enpoint, orig_disk_enpoint
+            tmp_disk_endpoint, orig_disk_endpoint
         ):
             raise RuntimeError(
-                f"Endpoint of tmp object storage disk is not equal to original (original {orig_disk_enpoint}  tmp: {tmp_disk_enpoint})."
+                f"Endpoint of tmp object storage disk is not equal to original (original {orig_disk_endpoint}  tmp: {tmp_disk_endpoint})."
                 "It is required for inplace restore mode."
             )
 
-        disk_config["endpoint"] = tmp_disk_enpoint
+        disk_config["endpoint"] = tmp_disk_endpoint
 
         disks_config = {tmp_disk_name: disk_config}
 

--- a/ch_backup/clickhouse/disks.py
+++ b/ch_backup/clickhouse/disks.py
@@ -74,9 +74,7 @@ class ClickHouseTemporaryDisks:
         self._ch_availible_disks: Dict[str, Disk] = {}
 
     def __enter__(self):
-        self._disks = (self._ch_config.config.get("storage_configuration") or {}).get(
-            "disks"
-        ) or {}
+        self._disks = self._ch_config.config.get("storage_configuration", {}).get("disks", {})
         for disk_name in self._backup_meta.cloud_storage.disks:
             self._create_temporary_disk(
                 self._backup_meta,

--- a/images/clickhouse/config/no_storage_configuration.xml
+++ b/images/clickhouse/config/no_storage_configuration.xml
@@ -1,0 +1,6 @@
+<yandex>
+    <!-- Intentionally empty: no storage_configuration section.
+         Used in integration tests to verify that ch-backup handles
+         a ClickHouse instance that relies solely on the built-in
+         default disk (no custom disks / S3 configuration). -->
+</yandex>

--- a/images/clickhouse/config/storage_configuration_without_s3.xml
+++ b/images/clickhouse/config/storage_configuration_without_s3.xml
@@ -1,0 +1,52 @@
+<yandex>
+    <!-- Storage configuration intentionally missing the 's3' disk.
+         Used in integration tests to verify that ch-backup raises
+         ClickHouseDisksException (not a bare KeyError) when a disk
+         referenced in backup cloud_storage metadata is absent from
+         the ClickHouse storage_configuration. -->
+    <storage_configuration>
+        <disks>
+            <hdd1>
+                <path>/hdd1/</path>
+            </hdd1>
+            <hdd2>
+                <path>/hdd2/</path>
+            </hdd2>
+        </disks>
+
+        <policies>
+            <multiple_disks>
+                <volumes>
+                    <main>
+                        <disk>default</disk>
+                    </main>
+                    <hdd1>
+                        <disk>hdd1</disk>
+                    </hdd1>
+                    <hdd2>
+                        <disk>hdd2</disk>
+                    </hdd2>
+                </volumes>
+                <move_factor>0.0</move_factor>
+            </multiple_disks>
+
+            <s3>
+                <volumes>
+                    <main>
+                        <disk>default</disk>
+                    </main>
+                </volumes>
+                <move_factor>0.0</move_factor>
+            </s3>
+
+            <s3_cold>
+                <volumes>
+                    <main>
+                        <disk>default</disk>
+                    </main>
+                </volumes>
+                <move_factor>0.0</move_factor>
+            </s3_cold>
+        </policies>
+    </storage_configuration>
+</yandex>

--- a/tests/integration/features/cloud_storage.feature
+++ b/tests/integration/features/cloud_storage.feature
@@ -254,3 +254,66 @@ Feature: Backup & Clean & Restore
     Examples:
     | object_count |
     | 11           |
+
+  Scenario: Restore succeeds when target node has no storage_configuration section
+    # Regression test for: ClickHouseTemporaryDisks.__enter__ raised KeyError when
+    # storage_configuration was absent from the ClickHouse config.
+    # The backup here uses only the default disk (no cloud_storage disks),
+    # so __enter__ must complete without error even on a node with no
+    # storage_configuration section.
+    Given a working clickhouse on clickhouse02
+    When we execute queries on clickhouse01
+    """
+    CREATE DATABASE IF NOT EXISTS test_db;
+    CREATE TABLE test_db.table_no_s3 (
+        CounterID UInt32,
+        UserID    UInt32
+    )
+    ENGINE = MergeTree()
+    ORDER BY UserID;
+    INSERT INTO test_db.table_no_s3 VALUES (0, 1), (1, 2);
+    """
+    And we create clickhouse01 clickhouse backup
+    Then we got the following backups on clickhouse01
+      | num | state   | data_count | link_count |
+      | 0   | created | 1          | 0          |
+    When we replace config file storage_configuration.xml in favor of no_storage_configuration.xml on clickhouse02 with restart
+    And we restore clickhouse backup #0 to clickhouse02
+    Then we got same clickhouse data at clickhouse01 clickhouse02
+
+  @require_version_22.8
+  Scenario: Restore with cloud_storage disks fails with a clear error when disk is absent from target config
+    # Regression test for: _create_temporary_disk raised an opaque KeyError instead of
+    # ClickHouseDisksException when the disk referenced in backup cloud_storage metadata
+    # was missing from the target node's storage_configuration.
+    # We use storage_configuration_without_s3.xml on clickhouse02: it keeps the s3/s3_cold
+    # storage policies (so the table schema can be restored) but removes the actual 's3'
+    # disk entry, which triggers ClickHouseDisksException in __enter__.
+    Given a working clickhouse on clickhouse02
+    When we execute queries on clickhouse01
+    """
+    CREATE DATABASE IF NOT EXISTS test_db;
+    CREATE TABLE test_db.table_s3 (
+        CounterID UInt32,
+        UserID    UInt32
+    )
+    ENGINE = MergeTree()
+    ORDER BY UserID
+    SETTINGS storage_policy = 's3';
+    INSERT INTO test_db.table_s3 VALUES (0, 1), (1, 2);
+    """
+    And we create clickhouse01 clickhouse backup
+    Then we got the following backups on clickhouse01
+      | num | state   | data_count | link_count |
+      | 0   | created | 1          | 0          |
+    When we replace config file storage_configuration.xml in favor of storage_configuration_without_s3.xml on clickhouse02 with restart
+    And we try to execute command on clickhouse02
+    """
+    ch-backup -c /etc/yandex/ch-backup/ch-backup.conf restore LAST \
+        --cloud-storage-source-bucket cloud-storage-01 \
+        --cloud-storage-source-path data
+    """
+    Then we get response contains
+    """
+    missing from ClickHouse storage_configuration
+    """

--- a/tests/unit/test_disks.py
+++ b/tests/unit/test_disks.py
@@ -3,12 +3,16 @@ Unit tests disks module.
 """
 
 import unittest
+from typing import List, Optional
 
 import xmltodict
 
 from ch_backup.backup_context import BackupContext
 from ch_backup.clickhouse.config import ClickhouseConfig
-from ch_backup.clickhouse.disks import ClickHouseTemporaryDisks
+from ch_backup.clickhouse.disks import (
+    ClickHouseDisksException,
+    ClickHouseTemporaryDisks,
+)
 from ch_backup.config import DEFAULT_CONFIG, Config
 from tests.unit.utils import assert_equal, parametrize
 
@@ -182,6 +186,10 @@ def test_temporary_disk(clickhouse_config, disk_name, source, temp_config):
         m().write = write_collector
 
         # pylint: disable=protected-access
+        # Initialise _disks the same way __enter__ does
+        disk._disks = (context.ch_config.config.get("storage_configuration") or {}).get(
+            "disks"
+        ) or {}
         disk._create_temporary_disk(
             context.backup_meta,
             disk_name,
@@ -204,3 +212,99 @@ def write_collector(x):
     # pylint: disable=global-statement
     global write_result
     write_result += x.decode("utf-8")
+
+
+def _make_temporary_disks(
+    clickhouse_config_xml: str,
+    cloud_storage_disks: Optional[List[str]] = None,
+) -> ClickHouseTemporaryDisks:
+    """Helper: build ClickHouseTemporaryDisks with mocked dependencies."""
+    context = BackupContext(DEFAULT_CONFIG)  # type: ignore[arg-type]
+    context.ch_ctl = unittest.mock.MagicMock()
+    context.backup_layout = unittest.mock.MagicMock()
+    context.backup_meta = unittest.mock.MagicMock()
+    context.backup_meta.cloud_storage.disks = cloud_storage_disks or []
+    context.backup_meta.cloud_storage.enabled = bool(cloud_storage_disks)
+    with unittest.mock.patch(
+        "builtins.open",
+        new=unittest.mock.mock_open(read_data=clickhouse_config_xml),
+        create=True,
+    ):
+        with unittest.mock.patch("yaml.load", return_value=""):
+            context.ch_config = ClickhouseConfig(Config("foo"))
+        context.ch_config.load()
+    # Pass a dummy bucket when cloud_storage_disks is non-empty, otherwise None
+    source_bucket = "test-bucket" if cloud_storage_disks else None
+    return ClickHouseTemporaryDisks(
+        context.ch_ctl,
+        context.backup_layout,
+        context.config_root,
+        context.backup_meta,
+        source_bucket,
+        None,
+        None,
+        context.ch_config,
+    )
+
+
+def test_enter_without_storage_configuration():
+    """
+    __enter__ must not raise KeyError when the ClickHouse config has no
+    storage_configuration section (valid CH config that uses the default disk).
+    """
+    clickhouse_config_xml = """
+        <clickhouse>
+            <logger>
+                <level>trace</level>
+            </logger>
+        </clickhouse>
+    """
+    disk_manager = _make_temporary_disks(clickhouse_config_xml, cloud_storage_disks=[])
+
+    with unittest.mock.patch("builtins.open", new=unittest.mock.mock_open()):
+        with disk_manager:
+            # pylint: disable=protected-access
+            assert disk_manager._disks == {}
+
+
+def test_create_temporary_disk_missing_disk_raises():
+    """
+    _create_temporary_disk must raise ClickHouseDisksException with a descriptive
+    message when disk_name is present in backup cloud storage metadata but absent
+    from the ClickHouse storage_configuration.
+    """
+    clickhouse_config_xml = """
+        <clickhouse>
+            <storage_configuration>
+                <disks>
+                    <other_disk>
+                        <type>s3</type>
+                        <endpoint>https://localhost/bucket/path/</endpoint>
+                    </other_disk>
+                </disks>
+            </storage_configuration>
+        </clickhouse>
+    """
+    disk_manager = _make_temporary_disks(
+        clickhouse_config_xml, cloud_storage_disks=["missing_disk"]
+    )
+
+    with unittest.mock.patch("builtins.open", new=unittest.mock.mock_open()):
+        # Manually initialise _disks as __enter__ would
+        # pylint: disable=protected-access
+        disk_manager._disks = (
+            disk_manager._ch_config.config.get("storage_configuration") or {}
+        ).get("disks") or {}  # fmt: skip
+
+        try:
+            disk_manager._create_temporary_disk(
+                disk_manager._backup_meta,
+                "missing_disk",
+                "test-bucket",
+                "cluster1/shard1/",
+                "localhost",
+            )
+            assert False, "Expected ClickHouseDisksException was not raised"
+        except ClickHouseDisksException as exc:
+            assert "missing_disk" in str(exc)
+            assert "storage_configuration" in str(exc)


### PR DESCRIPTION
## Summary by Sourcery

Handle ClickHouse configurations without explicit storage_configuration disks and ensure missing cloud_storage disks produce clear errors.

Bug Fixes:
- Avoid KeyError in ClickHouseTemporaryDisks.__enter__ when storage_configuration or disks are absent in the ClickHouse config.
- Raise a descriptive ClickHouseDisksException when a disk referenced in backup cloud storage metadata is missing from the ClickHouse storage_configuration instead of failing with a bare KeyError.

Tests:
- Add unit tests covering ClickHouseTemporaryDisks behavior when storage_configuration is absent and when referenced disks are missing from the configuration.
- Add integration scenarios verifying successful restore on nodes without storage_configuration and clear error messaging when cloud_storage disks are missing from the target config.

Chores:
- Add ClickHouse config fixtures without storage_configuration and without the s3 disk for use in tests.