### PR TITLE
Add checking `change_time` between databases (support EXCHANGE TABLES)

### DIFF
--- a/ch_backup/clickhouse/models.py
+++ b/ch_backup/clickhouse/models.py
@@ -189,6 +189,11 @@ class Table(SimpleNamespace):
     def __hash__(self) -> int:  # type: ignore
         return hash((self.database, self.name))
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Table):
+            return NotImplemented
+        return self.database == other.database and self.name == other.name
+
     def is_dictionary(self) -> bool:
         """
         Return True if table is dictionary.

--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -84,6 +84,15 @@ class TableBackup(BackupManager):
         ):
             context.ch_ctl.kill_old_freeze_queries()
 
+        # Collect modification timestamps of table metadata files for all databases
+        # for optimistic concurrency control of backup creation.
+        # To ensure consistency between metadata and data backups in case of EXCHANGE TABLES
+        # within a single backup run.
+        # See https://en.wikipedia.org/wiki/Optimistic_concurrency_control
+        change_times = self._collect_local_metadata_change_times(
+            context, databases, db_tables
+        )
+
         for db in databases:
             self._backup(
                 context,
@@ -92,28 +101,35 @@ class TableBackup(BackupManager):
                 backup_name,
                 schema_only,
                 multiprocessing_config,
+                change_times,
             )
 
     def _collect_local_metadata_change_times(
-        self, context: BackupContext, db: Database, tables: Sequence[str]
-    ) -> Dict[str, TableMetadataChangeTime]:
+        self,
+        context: BackupContext,
+        databases: Sequence[Database],
+        db_tables: Dict[str, list],
+    ) -> Dict[Table, TableMetadataChangeTime]:
         """
         Collect modification timestamps of table metadata files.
         """
         logging.debug("Collecting local metadata modification times")
-        res = {}
+        res: Dict[Table, TableMetadataChangeTime] = {}
 
-        for table in context.ch_ctl.get_tables(db.name, tables):
-            change_time = self._get_change_time(table.metadata_path)
-            if change_time is None:
-                logging.warning(
-                    'Cannot get metadata change time for table "{}"."{}". Skipping it',
-                    table.database,
-                    table.name,
-                )
+        for db in databases:
+            if db.is_external_db_engine():
                 continue
+            for table in context.ch_ctl.get_tables(db.name, db_tables[db.name]):
+                change_time = self._get_change_time(table.metadata_path)
+                if change_time is None:
+                    logging.warning(
+                        'Cannot get metadata change time for table "{}"."{}". Skipping it',
+                        table.database,
+                        table.name,
+                    )
+                    continue
 
-            res[table.name] = change_time
+                res[table] = change_time
 
         return res
 
@@ -126,24 +142,17 @@ class TableBackup(BackupManager):
         backup_name: str,
         schema_only: bool,
         multiprocessing_config: Dict,
+        change_times: Dict[Table, TableMetadataChangeTime],
     ) -> None:
         """
         Backup single database tables.
         """
         if not db.is_external_db_engine():
-            # Collect modification timestamps of table metadata files for optimistic concurrency
-            # control of backup creation.
-            # To ensure consistency between metadata and data backups.
-            # See https://en.wikipedia.org/wiki/Optimistic_concurrency_control
-            change_times = self._collect_local_metadata_change_times(
-                context, db, tables
-            )
-            tables_ = list(
-                filter(
-                    lambda table: table.name in change_times,
-                    context.ch_ctl.get_tables(db.name, tables),
-                )
-            )
+            tables_ = [
+                table
+                for table in context.ch_ctl.get_tables(db.name, tables)
+                if table in change_times
+            ]
 
             create_statements_to_backup = []
 
@@ -425,13 +434,13 @@ class TableBackup(BackupManager):
         context: BackupContext,
         table: Table,
         backup_name: str,
-        change_times: Dict[str, TableMetadataChangeTime],
+        change_times: Dict[Table, TableMetadataChangeTime],
     ) -> bool:
         """
         Check if table metadata was updated.
         """
         new_change_time = self._get_change_time(table.metadata_path)
-        if new_change_time is not None and change_times[table.name] == new_change_time:
+        if new_change_time is not None and change_times[table] == new_change_time:
             return True
 
         logging.warning(

--- a/tests/unit/test_backup_tables.py
+++ b/tests/unit/test_backup_tables.py
@@ -19,57 +19,60 @@ class FakeStatResult:
     st_ctime_ns: int
 
 
+_STAT_UNCHANGED = FakeStatResult(
+    st_mtime_ns=16890001958000000, st_ctime_ns=16890001958000000
+)
+_STAT_MTIME_CHANGED = FakeStatResult(
+    st_mtime_ns=16890001958000111, st_ctime_ns=16890001958000000
+)
+_STAT_CTIME_CHANGED = FakeStatResult(
+    st_mtime_ns=16890001958000000, st_ctime_ns=16890001958000111
+)
+
+
 @pytest.mark.parametrize(
-    "fake_stats, backups_expected",
+    "fake_stats, backups_expected_db1, backups_expected_db2",
     [
+        # Metadata unchanged in both dbs -> both tables backed up
+        ([_STAT_UNCHANGED, _STAT_UNCHANGED, _STAT_UNCHANGED, _STAT_UNCHANGED], 1, 1),
+        # db1 table mtime changed after freeze -> db1 skipped, db2 backed up
         (
-            [
-                FakeStatResult(
-                    st_mtime_ns=16890001958000000, st_ctime_ns=16890001958000000
-                ),
-                FakeStatResult(
-                    st_mtime_ns=16890001958000000, st_ctime_ns=16890001958000000
-                ),
-            ],
+            [_STAT_UNCHANGED, _STAT_UNCHANGED, _STAT_MTIME_CHANGED, _STAT_UNCHANGED],
+            0,
             1,
         ),
+        # db1 table ctime changed after freeze -> db1 skipped, db2 backed up
         (
-            [
-                FakeStatResult(
-                    st_mtime_ns=16890001958000000, st_ctime_ns=16890001958000000
-                ),
-                FakeStatResult(
-                    st_mtime_ns=16890001958000111, st_ctime_ns=16890001958000000
-                ),
-            ],
+            [_STAT_UNCHANGED, _STAT_UNCHANGED, _STAT_CTIME_CHANGED, _STAT_UNCHANGED],
             0,
+            1,
         ),
+        # EXCHANGE TABLES between db1 and db2: db1 backed up normally,
+        # db2 table ctime changed (EXCHANGE happened) -> db2 skipped
         (
-            [
-                FakeStatResult(
-                    st_mtime_ns=16890001958000000, st_ctime_ns=16890001958000000
-                ),
-                FakeStatResult(
-                    st_mtime_ns=16890001958000000, st_ctime_ns=16890001958000111
-                ),
-            ],
+            [_STAT_UNCHANGED, _STAT_UNCHANGED, _STAT_UNCHANGED, _STAT_CTIME_CHANGED],
+            1,
             0,
         ),
     ],
 )
 def test_backup_table_skipping_if_metadata_updated_during_backup(
-    fake_stats: List[FakeStatResult], backups_expected: int
+    fake_stats: List[FakeStatResult],
+    backups_expected_db1: int,
+    backups_expected_db2: int,
 ) -> None:
     table_name = "table1"
-    db_name = "db1"
-    creation_statement = (
-        f"ATTACH TABLE db1.table1 UUID '{UUID}' (date Date) ENGINE = MergeTree();"
-    )
+    db1_name = "db1"
+    db2_name = "db2"
+    creation_statement = f"ATTACH TABLE {db1_name}.{table_name} UUID '{UUID}' (date Date) ENGINE = MergeTree();"
 
     # Prepare involved data objects
     context = BackupContext(DEFAULT_CONFIG)  # type: ignore[arg-type]
-    db = Database(
-        db_name, "MergeTree", "/var/lib/clickhouse/metadata/db1.sql", None, None
+    db1 = Database(
+        db1_name, "Atomic", "/var/lib/clickhouse/metadata/db1.sql", None, None
+    )
+    db2 = Database(
+        db2_name, "Atomic", "/var/lib/clickhouse/metadata/db2.sql", None, None
     )
     table_backup = TableBackup()
     backup_meta = BackupMetadata(
@@ -81,22 +84,41 @@ def test_backup_table_skipping_if_metadata_updated_during_backup(
         hostname="clickhouse01.test_net_711",
     )
 
-    backup_meta.add_database(db)
+    backup_meta.add_database(db1)
+    backup_meta.add_database(db2)
     context.backup_meta = backup_meta
 
     # Mock external interactions
+    # Each database has its own metadata path (EXCHANGE TABLES swaps inodes, not paths)
+    tables_by_db = {
+        db1_name: [
+            Table(
+                db1_name,
+                table_name,
+                "MergeTree",
+                [],
+                [],
+                f"/var/lib/clickhouse/metadata/{db1_name}/{table_name}.sql",
+                "",
+                UUID,
+            )
+        ],
+        db2_name: [
+            Table(
+                db2_name,
+                table_name,
+                "MergeTree",
+                [],
+                [],
+                f"/var/lib/clickhouse/metadata/{db2_name}/{table_name}.sql",
+                "",
+                UUID,
+            )
+        ],
+    }
     clickhouse_ctl_mock = Mock()
-    clickhouse_ctl_mock.get_tables.return_value = [
-        Table(
-            db_name,
-            table_name,
-            "MergeTree",
-            [],
-            [],
-            "/var/lib/clickhouse/metadata/db1/table1.sql",
-            "",
-            UUID,
-        ),
+    clickhouse_ctl_mock.get_tables.side_effect = lambda db_name, *a, **kw: tables_by_db[
+        db_name
     ]
     clickhouse_ctl_mock.get_disks.return_value = {}
     context.ch_ctl = clickhouse_ctl_mock
@@ -105,19 +127,19 @@ def test_backup_table_skipping_if_metadata_updated_during_backup(
 
     read_bytes_mock = Mock(return_value=creation_statement.encode())
 
-    # Backup table
     with (
         patch("os.stat", side_effect=fake_stats),
         patch("ch_backup.logic.table.Path", read_bytes=read_bytes_mock),
     ):
         table_backup.backup(
             context,
-            [db],
-            {db_name: [table_name]},
+            [db1, db2],
+            {db1_name: [table_name], db2_name: [table_name]},
             schema_only=False,
             multiprocessing_config=DEFAULT_CONFIG["multiprocessing"],  # type: ignore
         )
 
-    assert len(context.backup_meta.get_tables(db_name)) == backups_expected
-    # One call after each table and one after database is backuped
-    assert clickhouse_ctl_mock.remove_freezed_data.call_count == 2
+    assert len(context.backup_meta.get_tables(db1_name)) == backups_expected_db1
+    assert len(context.backup_meta.get_tables(db2_name)) == backups_expected_db2
+    # One call after each table and one after each database is backed up
+    assert clickhouse_ctl_mock.remove_freezed_data.call_count == 4


### PR DESCRIPTION
## Summary by Sourcery

Track and compare table metadata change times across all databases during backups to safely handle EXCHANGE TABLES and avoid backing up tables whose metadata changed mid-backup.

New Features:
- Support backing up tables across multiple databases while detecting metadata changes caused by EXCHANGE TABLES using per-table change timestamps.

Enhancements:
- Refactor metadata change-time collection to operate over all databases at once and index by table objects instead of table names.

Tests:
- Extend backup table skipping tests to cover multi-database scenarios and EXCHANGE TABLES behaviour, adjusting expectations for skipped tables and cleanup calls.