### PR TITLE
Support Proxy engine (in addition to StorageProxy)

### DIFF
--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -52,7 +52,7 @@ GET_TABLES_SQL = strip_query(
     FROM system.tables
     WHERE ({db_condition})
       AND ({tables_condition})
-      AND engine != 'StorageProxy'
+      AND engine NOT IN ('Proxy', 'StorageProxy')
 
     UNION ALL
 
@@ -68,7 +68,7 @@ GET_TABLES_SQL = strip_query(
     FROM system.tables
     WHERE ({db_condition})
       AND ({tables_condition})
-      AND engine = 'StorageProxy'
+      AND engine IN ('Proxy', 'StorageProxy')
 
     ORDER BY metadata_modification_time
     FORMAT JSON

--- a/tests/integration/modules/compose.py
+++ b/tests/integration/modules/compose.py
@@ -68,7 +68,7 @@ def _generate_compose_config(context: ContextT) -> dict:
 
     compose_conf: dict = {
         "networks": {
-            "test_net": {
+            "test-net": {
                 "name": network_name,
                 "external": True,
             },
@@ -139,7 +139,7 @@ def _generate_service_config(
         "domainname": network_name,
         "depends_on": dependency_list,
         # Networks. We use external anyway.
-        "networks": instance_config.get("networks", ["test_net"]),
+        "networks": instance_config.get("networks", ["test-net"]),
         "environment": instance_config.get("environment", []),
         # Nice container name with domain name part.
         # This results, however, in a strange rdns name:


### PR DESCRIPTION
Related 
https://github.com/ClickHouse/ClickHouse/pull/101128

## Summary by Sourcery

Add support for ClickHouse tables using the Proxy engine alongside StorageProxy and adjust test docker-compose network naming to match the expected external network.

Enhancements:
- Extend table engine filters to treat Proxy and StorageProxy engines consistently in backup-related queries.

Tests:
- Update integration test compose configuration to use the correct external network name for services.