### PR TITLE
Filtering out metadata for cloud storage

### DIFF
--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -14,6 +14,7 @@ from nacl.exceptions import CryptoError
 
 from ch_backup import logging
 from ch_backup.backup.metadata import BackupMetadata, PartMetadata
+from ch_backup.backup.metadata.table_metadata import TableMetadata
 from ch_backup.calculators import calc_encrypted_size, calc_tarball_size
 from ch_backup.clickhouse.models import Database, Disk, FrozenPart, Table
 from ch_backup.config import Config
@@ -652,6 +653,7 @@ class BackupLayout:
         backup_name: str,
         source_disk_name: str,
         compression: bool,
+        tables_needed: Optional[Sequence[TableMetadata]] = None,
     ) -> Sequence[str]:
         backup_path = self.get_backup_path(backup_name)
         # Check if metadata is stored as 'disks/s3.tar.gz' for backwards compatibility
@@ -660,11 +662,26 @@ class BackupLayout:
         )
         if self._storage_loader.path_exists(old_style_remote_path):
             return [old_style_remote_path]
-        return self._storage_loader.list_dir(
-            str(os.path.join(backup_path, "disks", source_disk_name)),
-            recursive=True,
-            absolute=True,
-        )
+
+        if tables_needed is None:
+            return self._storage_loader.list_dir(
+                str(os.path.join(backup_path, "disks", source_disk_name)),
+                recursive=True,
+                absolute=True,
+            )
+
+        remote_paths = []
+        for table in tables_needed:
+            remote_path = _disk_metadata_path(
+                backup_path,
+                table.database,
+                table.name,
+                source_disk_name,
+                compression,
+            )
+            if self._storage_loader.path_exists(remote_path):
+                remote_paths.append(remote_path)
+        return remote_paths
 
     @contextmanager
     def _get_cloud_storage_metadata_dst(
@@ -696,12 +713,14 @@ class BackupLayout:
             assert isinstance(path, str)
             return os.path.exists(path)
 
+    # pylint: disable=too-many-positional-arguments
     def download_cloud_storage_metadata(
         self,
         backup_meta: BackupMetadata,
         disk: Disk,
         source_disk_name: str,
         file_path: Optional[str] = None,
+        needed_tables: Optional[Sequence[TableMetadata]] = None,
     ) -> None:
         """
         Download files packed in tarball and unpacks them into specified directory.
@@ -711,7 +730,10 @@ class BackupLayout:
         compression = backup_meta.cloud_storage.compressed
         encryption = backup_meta.cloud_storage.encrypted
         metadata_remote_paths = self._get_cloud_storage_metadata_remote_paths(
-            backup_name, source_disk_name, compression
+            backup_name,
+            source_disk_name,
+            compression,
+            tables_needed=needed_tables,
         )
 
         with self._get_cloud_storage_metadata_dst(backup_meta, disk, file_path) as dst:

--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -674,10 +674,11 @@ class BackupLayout:
             return [old_style_remote_path]
 
         disk_path = os.path.join(backup_path, "disks", source_disk_name)
+        existing_paths = self._storage_loader.list_dir(
+            disk_path, recursive=True, absolute=True
+        )
         if desired_tables == "all":
-            return self._storage_loader.list_dir(
-                disk_path, recursive=True, absolute=True
-            )
+            return existing_paths
 
         remote_paths = {
             _disk_metadata_path(
@@ -689,9 +690,6 @@ class BackupLayout:
             )
             for table in desired_tables
         }
-        existing_paths = self._storage_loader.list_dir(
-            disk_path, recursive=True, absolute=True
-        )
         needed_paths = remote_paths.intersection(existing_paths)
         missing_paths = remote_paths.difference(existing_paths)
         for path in missing_paths:

--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -696,6 +696,7 @@ class BackupLayout:
         missing_paths = remote_paths.difference(existing_paths)
         for path in missing_paths:
             logging.warning(f"Missing path {path} on remote")
+
         return list(needed_paths)
 
     @contextmanager

--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -663,25 +663,32 @@ class BackupLayout:
         if self._storage_loader.path_exists(old_style_remote_path):
             return [old_style_remote_path]
 
+        disk_path = os.path.join(backup_path, "disks", source_disk_name)
         if tables_needed is None:
             return self._storage_loader.list_dir(
-                str(os.path.join(backup_path, "disks", source_disk_name)),
+                disk_path,
                 recursive=True,
                 absolute=True,
             )
 
-        remote_paths = []
-        for table in tables_needed:
-            remote_path = _disk_metadata_path(
+        remote_paths = {
+            _disk_metadata_path(
                 backup_path,
                 table.database,
                 table.name,
                 source_disk_name,
                 compression,
             )
-            if self._storage_loader.path_exists(remote_path):
-                remote_paths.append(remote_path)
-        return remote_paths
+            for table in tables_needed
+        }
+        existing_paths = self._storage_loader.list_dir(
+            disk_path, recursive=True, absolute=True
+        )
+        needed_paths = remote_paths.intersection(existing_paths)
+        missing_paths = remote_paths.difference(existing_paths)
+        for path in missing_paths:
+            logging.warning(f"Missing path {path} on remote")
+        return list(needed_paths)
 
     @contextmanager
     def _get_cloud_storage_metadata_dst(

--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -7,7 +7,17 @@ from contextlib import contextmanager
 from functools import partial
 from io import IOBase
 from pathlib import Path
-from typing import Any, BinaryIO, Callable, Iterator, List, Optional, Sequence, Union
+from typing import (
+    Any,
+    BinaryIO,
+    Callable,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Union,
+)
 from urllib.parse import quote
 
 from nacl.exceptions import CryptoError
@@ -653,7 +663,7 @@ class BackupLayout:
         backup_name: str,
         source_disk_name: str,
         compression: bool,
-        tables_needed: Optional[Sequence[TableMetadata]] = None,
+        desired_tables: Sequence[TableMetadata] | Literal["all"],
     ) -> Sequence[str]:
         backup_path = self.get_backup_path(backup_name)
         # Check if metadata is stored as 'disks/s3.tar.gz' for backwards compatibility
@@ -664,11 +674,9 @@ class BackupLayout:
             return [old_style_remote_path]
 
         disk_path = os.path.join(backup_path, "disks", source_disk_name)
-        if tables_needed is None:
+        if desired_tables == "all":
             return self._storage_loader.list_dir(
-                disk_path,
-                recursive=True,
-                absolute=True,
+                disk_path, recursive=True, absolute=True
             )
 
         remote_paths = {
@@ -679,7 +687,7 @@ class BackupLayout:
                 source_disk_name,
                 compression,
             )
-            for table in tables_needed
+            for table in desired_tables
         }
         existing_paths = self._storage_loader.list_dir(
             disk_path, recursive=True, absolute=True
@@ -726,8 +734,8 @@ class BackupLayout:
         backup_meta: BackupMetadata,
         disk: Disk,
         source_disk_name: str,
+        desired_tables: Sequence[TableMetadata] | Literal["all"],
         file_path: Optional[str] = None,
-        needed_tables: Optional[Sequence[TableMetadata]] = None,
     ) -> None:
         """
         Download files packed in tarball and unpacks them into specified directory.
@@ -740,7 +748,7 @@ class BackupLayout:
             backup_name,
             source_disk_name,
             compression,
-            tables_needed=needed_tables,
+            desired_tables,
         )
 
         with self._get_cloud_storage_metadata_dst(backup_meta, disk, file_path) as dst:

--- a/ch_backup/ch_backup.py
+++ b/ch_backup/ch_backup.py
@@ -471,7 +471,7 @@ class ClickhouseBackup:
             return False
 
         self._context.backup_layout.download_cloud_storage_metadata(
-            backup_meta, source_disk, disk_name, local_path
+            backup_meta, source_disk, disk_name, "all", local_path
         )
         self._context.backup_layout.wait()
 

--- a/ch_backup/clickhouse/disks.py
+++ b/ch_backup/clickhouse/disks.py
@@ -7,7 +7,7 @@ import os
 from functools import partial
 from subprocess import PIPE, Popen
 from types import TracebackType
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type
+from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Type
 from urllib.parse import urlparse
 
 import xmltodict
@@ -15,6 +15,7 @@ import xmltodict
 from ch_backup import logging
 from ch_backup.backup.layout import BackupLayout
 from ch_backup.backup.metadata import BackupMetadata, PartMetadata
+from ch_backup.backup.metadata.table_metadata import TableMetadata
 from ch_backup.clickhouse.config import ClickhouseConfig
 from ch_backup.clickhouse.control import ClickhouseCTL
 from ch_backup.clickhouse.models import Disk, Table
@@ -41,7 +42,7 @@ class ClickHouseTemporaryDisks:
     Manages temporary cloud storage disks.
     """
 
-    # pylint: disable=too-many-instance-attributes,too-many-positional-arguments
+    # pylint: disable=too-many-instance-attributes,too-many-positional-arguments,too-many-arguments
     def __init__(
         self,
         ch_ctl: ClickhouseCTL,
@@ -52,6 +53,7 @@ class ClickHouseTemporaryDisks:
         source_path: Optional[str],
         source_endpoint: Optional[str],
         ch_config: ClickhouseConfig,
+        desired_tables: Sequence[TableMetadata] | Literal["all"] = "all",
         use_local_copy: bool = False,
     ):
         self._ch_ctl = ch_ctl
@@ -68,6 +70,7 @@ class ClickHouseTemporaryDisks:
             raise RuntimeError(
                 "Backup contains cloud storage data, cloud-storage-source-bucket must be set."
             )
+        self._desired_tables: Sequence[TableMetadata] | Literal["all"] = desired_tables
 
         self._disks: Dict[str, Dict] = {}
         self._created_disks: Dict[str, Disk] = {}
@@ -77,7 +80,16 @@ class ClickHouseTemporaryDisks:
         self._disks = self._ch_config.config.get("storage_configuration", {}).get(
             "disks", {}
         )
-        self._prepare_temporary_disks()
+        for disk_name in self._backup_meta.cloud_storage.disks:
+            self._create_temporary_disk(
+                self._backup_meta,
+                disk_name,
+                self._source_bucket,
+                self._source_path,
+                self._source_endpoint,
+                self._desired_tables,
+            )
+        self._backup_layout.wait()
         self._ch_availible_disks = self._ch_ctl.get_disks()
         self._render_disks_config(
             CH_DISK_CONFIG_PATH,
@@ -124,31 +136,6 @@ class ClickHouseTemporaryDisks:
                 pretty=True,
             )
 
-    def restore_cloud_storage_metadata(
-        self,
-        cloud_metadata_tables: Optional[Sequence] = None,
-    ) -> None:
-        """
-        Restores storage metadata, filtering for provided tables.
-        If no tables are provided, every table metadata is considered.
-        """
-        self._prepare_temporary_disks(cloud_metadata_tables)
-
-    def _prepare_temporary_disks(
-        self,
-        cloud_metadata_tables: Optional[Sequence] = None,
-    ) -> None:
-        for disk_name in self._backup_meta.cloud_storage.disks:
-            self._create_temporary_disk(
-                self._backup_meta,
-                disk_name,
-                self._source_bucket,
-                self._source_path,
-                self._source_endpoint,
-                cloud_metadata_tables,
-            )
-        self._backup_layout.wait()
-
     # pylint: disable=too-many-positional-arguments
     def _create_temporary_disk(
         self,
@@ -157,7 +144,7 @@ class ClickHouseTemporaryDisks:
         source_bucket: str,
         source_path: str,
         source_endpoint: str,
-        cloud_metadata_tables: Optional[Sequence] = None,
+        desired_tables: Sequence[TableMetadata] | Literal["all"] = "all",
     ) -> None:
         tmp_disk_name = _get_tmp_disk_name(disk_name)
         logging.debug(f"Creating tmp disk {tmp_disk_name}")
@@ -219,7 +206,7 @@ class ClickHouseTemporaryDisks:
             backup_meta,
             source_disk,
             disk_name,
-            needed_tables=cloud_metadata_tables,
+            desired_tables,
         )
 
         self._created_disks[tmp_disk_name] = source_disk

--- a/ch_backup/clickhouse/disks.py
+++ b/ch_backup/clickhouse/disks.py
@@ -7,7 +7,7 @@ import os
 from functools import partial
 from subprocess import PIPE, Popen
 from types import TracebackType
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type
 from urllib.parse import urlparse
 
 import xmltodict
@@ -77,15 +77,7 @@ class ClickHouseTemporaryDisks:
         self._disks = self._ch_config.config.get("storage_configuration", {}).get(
             "disks", {}
         )
-        for disk_name in self._backup_meta.cloud_storage.disks:
-            self._create_temporary_disk(
-                self._backup_meta,
-                disk_name,
-                self._source_bucket,
-                self._source_path,
-                self._source_endpoint,
-            )
-        self._backup_layout.wait()
+        self._prepare_temporary_disks()
         self._ch_availible_disks = self._ch_ctl.get_disks()
         self._render_disks_config(
             CH_DISK_CONFIG_PATH,
@@ -132,6 +124,31 @@ class ClickHouseTemporaryDisks:
                 pretty=True,
             )
 
+    def restore_cloud_storage_metadata(
+        self,
+        cloud_metadata_tables: Optional[Sequence] = None,
+    ) -> None:
+        """
+        Restores storage metadata, filtering for provided tables.
+        If no tables are provided, every table metadata is considered.
+        """
+        self._prepare_temporary_disks(cloud_metadata_tables)
+
+    def _prepare_temporary_disks(
+        self,
+        cloud_metadata_tables: Optional[Sequence] = None,
+    ) -> None:
+        for disk_name in self._backup_meta.cloud_storage.disks:
+            self._create_temporary_disk(
+                self._backup_meta,
+                disk_name,
+                self._source_bucket,
+                self._source_path,
+                self._source_endpoint,
+                cloud_metadata_tables,
+            )
+        self._backup_layout.wait()
+
     # pylint: disable=too-many-positional-arguments
     def _create_temporary_disk(
         self,
@@ -140,6 +157,7 @@ class ClickHouseTemporaryDisks:
         source_bucket: str,
         source_path: str,
         source_endpoint: str,
+        cloud_metadata_tables: Optional[Sequence] = None,
     ) -> None:
         tmp_disk_name = _get_tmp_disk_name(disk_name)
         logging.debug(f"Creating tmp disk {tmp_disk_name}")
@@ -198,7 +216,10 @@ class ClickHouseTemporaryDisks:
         source_disk = self._ch_ctl.get_disk(tmp_disk_name)
         logging.debug(f'Restoring Cloud Storage "shadow" data of disk "{disk_name}"')
         self._backup_layout.download_cloud_storage_metadata(
-            backup_meta, source_disk, disk_name
+            backup_meta,
+            source_disk,
+            disk_name,
+            needed_tables=cloud_metadata_tables,
         )
 
         self._created_disks[tmp_disk_name] = source_disk

--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -421,6 +421,7 @@ class TableBackup(BackupManager):
             context.ch_config,
             use_local_copy=use_inplace_cloud_restore,
         ) as disks:
+            disks.restore_cloud_storage_metadata(cloud_metadata_tables=tables_meta)
             self._restore_data(
                 context,
                 tables=tables_to_restore_data,

--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -419,9 +419,9 @@ class TableBackup(BackupManager):
             cloud_storage_source_path,
             cloud_storage_source_endpoint,
             context.ch_config,
+            desired_tables=tables_meta,
             use_local_copy=use_inplace_cloud_restore,
         ) as disks:
-            disks.restore_cloud_storage_metadata(cloud_metadata_tables=tables_meta)
             self._restore_data(
                 context,
                 tables=tables_to_restore_data,

--- a/tests/unit/test_layout.py
+++ b/tests/unit/test_layout.py
@@ -48,7 +48,7 @@ class TestCloudStorageMetadataRemotePaths:
             backup_name,
             source_disk_name,
             compression=False,
-            tables_needed=tables,
+            desired_tables=tables,
         )
 
         assert list(remote_paths) == expected_paths

--- a/tests/unit/test_layout.py
+++ b/tests/unit/test_layout.py
@@ -1,5 +1,6 @@
 """Unit tests for backup layout cloud metadata path selection."""
 
+from collections import Counter
 from unittest.mock import MagicMock, patch
 
 from ch_backup.backup.layout import BackupLayout
@@ -36,13 +37,11 @@ class TestCloudStorageMetadataRemotePaths:
             f"{backup_path}/disks/{source_disk_name}/db1/table1.tar",
             f"{backup_path}/disks/{source_disk_name}/db2/table3.tar",
         ]
-        existing_paths = {
-            old_style_path: False,
-            **{path: True for path in expected_paths},
-        }
-        existing_paths[f"{backup_path}/disks/{source_disk_name}/db1/table2.tar"] = False
 
-        layout._storage_loader.path_exists.side_effect = existing_paths.get
+        layout._storage_loader.path_exists.side_effect = {old_style_path: False}.get
+        layout._storage_loader.list_dir.side_effect = (
+            lambda _disk_path, **_kwargs: expected_paths
+        )
 
         remote_paths = layout._get_cloud_storage_metadata_remote_paths(
             backup_name,
@@ -51,5 +50,4 @@ class TestCloudStorageMetadataRemotePaths:
             desired_tables=tables,
         )
 
-        assert list(remote_paths) == expected_paths
-        layout._storage_loader.list_dir.assert_not_called()
+        assert Counter(remote_paths) == Counter(expected_paths)

--- a/tests/unit/test_layout.py
+++ b/tests/unit/test_layout.py
@@ -1,0 +1,55 @@
+"""Unit tests for backup layout cloud metadata path selection."""
+
+from unittest.mock import MagicMock, patch
+
+from ch_backup.backup.layout import BackupLayout
+from ch_backup.backup.metadata.table_metadata import TableMetadata
+from ch_backup.config import DEFAULT_CONFIG
+
+
+class TestCloudStorageMetadataRemotePaths:
+    """Tests for filtered cloud metadata remote path selection."""
+
+    # pylint: disable=protected-access
+
+    def test_prefers_old_style_and_filters_exact_per_table_paths(self):
+        with (
+            patch("ch_backup.backup.layout.StorageLoader"),
+            patch("ch_backup.backup.layout.get_encryption") as get_encryption,
+        ):
+            get_encryption.return_value.metadata_size.return_value = 0
+            layout = BackupLayout(DEFAULT_CONFIG)  # type: ignore[arg-type]
+        layout._storage_loader = MagicMock()
+        layout._config["path_root"] = "ch_backup"
+
+        backup_name = "backup"
+        source_disk_name = "s3"
+        tables = [
+            TableMetadata("db1", "table1", "MergeTree", None),
+            TableMetadata("db1", "table2", "MergeTree", None),
+            TableMetadata("db2", "table3", "MergeTree", None),
+        ]
+
+        backup_path = layout.get_backup_path(backup_name)
+        old_style_path = f"{backup_path}/disks/{source_disk_name}.tar"
+        expected_paths = [
+            f"{backup_path}/disks/{source_disk_name}/db1/table1.tar",
+            f"{backup_path}/disks/{source_disk_name}/db2/table3.tar",
+        ]
+        existing_paths = {
+            old_style_path: False,
+            **{path: True for path in expected_paths},
+        }
+        existing_paths[f"{backup_path}/disks/{source_disk_name}/db1/table2.tar"] = False
+
+        layout._storage_loader.path_exists.side_effect = existing_paths.get
+
+        remote_paths = layout._get_cloud_storage_metadata_remote_paths(
+            backup_name,
+            source_disk_name,
+            compression=False,
+            tables_needed=tables,
+        )
+
+        assert list(remote_paths) == expected_paths
+        layout._storage_loader.list_dir.assert_not_called()

--- a/tests/unit/test_layout.py
+++ b/tests/unit/test_layout.py
@@ -39,9 +39,10 @@ class TestCloudStorageMetadataRemotePaths:
         ]
 
         layout._storage_loader.path_exists.side_effect = {old_style_path: False}.get
-        layout._storage_loader.list_dir.side_effect = (
-            lambda _disk_path, **_kwargs: expected_paths
-        )
+        layout._storage_loader.list_dir.side_effect = lambda _disk_path, **_kwargs: [
+            *expected_paths,
+            f"{backup_path}/disks/{source_disk_name}/db2/table4.tar",
+        ]
 
         remote_paths = layout._get_cloud_storage_metadata_remote_paths(
             backup_name,


### PR DESCRIPTION
## Summary by Sourcery

Filter and selectively restore cloud storage metadata for specific tables during backup restoration.

New Features:
- Allow restoring cloud storage metadata only for specified tables instead of always restoring all metadata.

Enhancements:
- Refactor temporary disk preparation into a reusable helper to support filtered metadata restores.

Tests:
- Add unit test coverage for selecting cloud storage metadata paths when filtering by tables and when old-style metadata archives are present.