### PR TITLE
Add zookeeper client's timeout in config

### DIFF
--- a/ch_backup/config.py
+++ b/ch_backup/config.py
@@ -235,6 +235,7 @@ DEFAULT_CONFIG = {
         "cert": None,
         "key": None,
         "ca": None,
+        "timeout": 10,
         "connect_timeout": 10,
         "hosts": [],
         "root_path": "",

--- a/ch_backup/zookeeper/zookeeper.py
+++ b/ch_backup/zookeeper/zookeeper.py
@@ -23,6 +23,7 @@ class ZookeeperClient:
     def __init__(self, config: dict):
         self._client = KazooClient(
             config["hosts"],
+            timeout=config.get("timeout"),
             use_ssl=config.get("secure"),
             certfile=config.get("cert"),
             keyfile=config.get("key"),


### PR DESCRIPTION
Add zookeeper client's timeout in config

## Summary by Sourcery

Enhancements:
- Introduce a default timeout value in the Zookeeper configuration and pass it through to the underlying Kazoo client.