### PR TITLE
Optimizing GET_DATABASES_SQL

### DIFF
--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -295,7 +295,7 @@ GET_DATABASES_SQL = strip_query(
         engine,
         metadata_path,
         uuid,
-        engine_full
+        if(engine = 'Replicated', engine_full, NULL) AS engine_full
     FROM system.databases
     WHERE name NOT IN ('system', '_temporary_and_external_tables', 'information_schema', 'INFORMATION_SCHEMA', '{system_db}')
     FORMAT JSON


### PR DESCRIPTION
Excluding `engine_full` from system.databases listing (except for Replicated) to avoid hangups of external databases (currently PostgreSQL)

## Summary by Sourcery

Bug Fixes:
- Avoid hangs when querying system.databases against external databases by not resolving engine_full for non-Replicated engines.