### PR TITLE
[MDB-47576] Optimize GET_DATABASES_SQL

### DIFF
--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -295,9 +295,22 @@ GET_DATABASES_SQL = strip_query(
         engine,
         metadata_path,
         uuid,
-        if(engine = 'Replicated', engine_full, NULL) AS engine_full
+        CAST(engine_full, 'Nullable(String)') AS engine_full
     FROM system.databases
-    WHERE name NOT IN ('system', '_temporary_and_external_tables', 'information_schema', 'INFORMATION_SCHEMA', '{system_db}')
+    WHERE 
+        engine = 'Replicated' AND
+        name NOT IN ('system', '_temporary_and_external_tables', 'information_schema', 'INFORMATION_SCHEMA', '{system_db}')
+    UNION ALL
+    SELECT
+        name,
+        engine,
+        metadata_path,
+        uuid,
+        CAST(NULL, 'Nullable(String)') AS engine_full
+    FROM system.databases
+    WHERE 
+        engine != 'Replicated' AND
+        name NOT IN ('system', '_temporary_and_external_tables', 'information_schema', 'INFORMATION_SCHEMA', '{system_db}')
     FORMAT JSON
 """
 )

--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -297,7 +297,7 @@ GET_DATABASES_SQL = strip_query(
         uuid,
         CAST(engine_full, 'Nullable(String)') AS engine_full
     FROM system.databases
-    WHERE 
+    WHERE
         engine = 'Replicated' AND
         name NOT IN ('system', '_temporary_and_external_tables', 'information_schema', 'INFORMATION_SCHEMA', '{system_db}')
     UNION ALL
@@ -308,7 +308,7 @@ GET_DATABASES_SQL = strip_query(
         uuid,
         CAST(NULL, 'Nullable(String)') AS engine_full
     FROM system.databases
-    WHERE 
+    WHERE
         engine != 'Replicated' AND
         name NOT IN ('system', '_temporary_and_external_tables', 'information_schema', 'INFORMATION_SCHEMA', '{system_db}')
     FORMAT JSON


### PR DESCRIPTION
## Summary by Sourcery

Refine the GET_DATABASES_SQL query to handle replicated and non-replicated databases separately while preserving nullable engine_full handling.