### PR TITLE
Support Yandex mirrors

### DIFF
--- a/Dockerfile-deb-build
+++ b/Dockerfile-deb-build
@@ -4,18 +4,67 @@ FROM --platform=$TARGETPLATFORM $BASE_IMAGE
 ARG DEBIAN_FRONTEND=noninteractive
 ARG USE_YANDEX_MIRROR=false
 
-RUN if [ "$USE_YANDEX_MIRROR" = "true" ]; then \
-      sed -i \
-        's|http://ports.ubuntu.com/ubuntu-ports|https://mirror.yandex.ru/ubuntu-ports|g' \
-        /etc/apt/sources.list; \
+RUN <<'EOF'
+set -eux
+
+if [ "${USE_YANDEX_MIRROR}" = "true" ]; then
+    # Install TLS and GPG tooling from the original Ubuntu repositories before
+    # switching to the HTTPS mirror.
+    apt-get update
+
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        dirmngr \
+        gnupg
+
+    # Замена Ubuntu Ports на зеркало Yandex
+    if [ -f /etc/apt/sources.list ]; then
+        sed -i \
+            's|https\?://ports.ubuntu.com/ubuntu-ports|https://mirror.yandex.ru/ubuntu-ports|g' \
+            /etc/apt/sources.list
     fi
+
+    if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+        sed -i \
+            's|https\?://ports.ubuntu.com/ubuntu-ports|https://mirror.yandex.ru/ubuntu-ports|g' \
+            /etc/apt/sources.list.d/ubuntu.sources
+    fi
+
+    apt-get update
+
+    repo_gnupg="$(mktemp -d)"
+
+    GNUPGHOME="${repo_gnupg}" gpg --batch \
+        --keyserver hkps://keyserver.ubuntu.com \
+        --recv-keys 38D6BC95962097203B8E2E45FF5F4D0E27393420
+
+    GNUPGHOME="${repo_gnupg}" gpg --batch \
+        --export 38D6BC95962097203B8E2E45FF5F4D0E27393420 \
+        > /usr/share/keyrings/common.dist.yandex.gpg
+
+    rm -rf "${repo_gnupg}"
+
+    arch="$(dpkg --print-architecture)"
+
+    printf '%s\n' \
+        'deb [signed-by=/usr/share/keyrings/common.dist.yandex.gpg] http://common.dist.yandex.ru/common stable/all/' \
+        "deb [arch=${arch} signed-by=/usr/share/keyrings/common.dist.yandex.gpg] http://common.dist.yandex.ru/common stable/${arch}/" \
+        > /etc/apt/sources.list.d/yandex.list
+
+    apt-get update
+
+    apt-get install -y --no-install-recommends \
+        yandex-internal-root-ca
+
+    update-ca-certificates
+fi
+EOF
 
 RUN set -ex \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        yandex-internal-root-ca \
         # Debian packaging tools
-        build-essential \        
+        build-essential \
         debhelper \
         devscripts \
         fakeroot \

--- a/Dockerfile-deb-build
+++ b/Dockerfile-deb-build
@@ -2,14 +2,16 @@ ARG BASE_IMAGE=ubuntu:22.04
 FROM --platform=$TARGETPLATFORM $BASE_IMAGE
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG DEB_BUILD_MIRROR=""
 ARG USE_YANDEX_MIRROR=false
 
 RUN <<'EOF'
 set -eux
 
-if [ "${USE_YANDEX_MIRROR}" = "true" ]; then
-    # Install TLS and GPG tooling from the original Ubuntu repositories before
-    # switching to the HTTPS mirror.
+arch="$(dpkg --print-architecture)"
+
+if [ -n "${DEB_BUILD_MIRROR}" ] || [ "${USE_YANDEX_MIRROR}" = "true" ]; then
+    # Bootstrap TLS and GPG tooling from the original Ubuntu repositories.
     apt-get update
 
     apt-get install -y --no-install-recommends \
@@ -17,21 +19,37 @@ if [ "${USE_YANDEX_MIRROR}" = "true" ]; then
         dirmngr \
         gnupg
 
-    # Замена Ubuntu Ports на зеркало Yandex
-    if [ -f /etc/apt/sources.list ]; then
-        sed -i \
-            's|https\?://ports.ubuntu.com/ubuntu-ports|https://mirror.yandex.ru/ubuntu-ports|g' \
-            /etc/apt/sources.list
+fi
+
+if [ -n "${DEB_BUILD_MIRROR}" ]; then
+    mirror="${DEB_BUILD_MIRROR%/}"
+
+    if [ "${arch}" = "amd64" ]; then
+        source_pattern='https?://(archive\.ubuntu\.com/ubuntu|security\.ubuntu\.com/ubuntu)'
+    elif [ "${arch}" = "arm64" ]; then
+        source_pattern='https?://ports\.ubuntu\.com/ubuntu-ports'
+    else
+        echo "Error: Ubuntu mirror replacement is not configured for architecture ${arch}" >&2
+        exit 1
     fi
 
-    if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
-        sed -i \
-            's|https\?://ports.ubuntu.com/ubuntu-ports|https://mirror.yandex.ru/ubuntu-ports|g' \
-            /etc/apt/sources.list.d/ubuntu.sources
-    fi
+    echo "Using Ubuntu mirror ${mirror} for architecture ${arch}"
+
+    for sources_file in \
+        /etc/apt/sources.list \
+        /etc/apt/sources.list.d/ubuntu.sources
+    do
+        if [ -f "${sources_file}" ]; then
+            sed -Ei \
+                "s#${source_pattern}#${mirror}#g" \
+                "${sources_file}"
+        fi
+    done
 
     apt-get update
+fi
 
+if [ "${USE_YANDEX_MIRROR}" = "true" ]; then
     repo_gnupg="$(mktemp -d)"
 
     GNUPGHOME="${repo_gnupg}" gpg --batch \
@@ -43,8 +61,6 @@ if [ "${USE_YANDEX_MIRROR}" = "true" ]; then
         > /usr/share/keyrings/common.dist.yandex.gpg
 
     rm -rf "${repo_gnupg}"
-
-    arch="$(dpkg --print-architecture)"
 
     printf '%s\n' \
         'deb [signed-by=/usr/share/keyrings/common.dist.yandex.gpg] http://common.dist.yandex.ru/common stable/all/' \

--- a/Dockerfile-deb-build
+++ b/Dockerfile-deb-build
@@ -2,6 +2,13 @@ ARG BASE_IMAGE=ubuntu:22.04
 FROM --platform=$TARGETPLATFORM $BASE_IMAGE
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG USE_YANDEX_MIRROR=false
+
+RUN if [ "$USE_YANDEX_MIRROR" = "true" ]; then \
+      sed -i \
+        's|http://ports.ubuntu.com/ubuntu-ports|https://mirror.yandex.ru/ubuntu-ports|g' \
+        /etc/apt/sources.list; \
+    fi
 
 RUN set -ex \
     && apt-get update \

--- a/Dockerfile-deb-build
+++ b/Dockerfile-deb-build
@@ -13,8 +13,9 @@ RUN if [ "$USE_YANDEX_MIRROR" = "true" ]; then \
 RUN set -ex \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
+        yandex-internal-root-ca \
         # Debian packaging tools
-        build-essential \
+        build-essential \        
         debhelper \
         devscripts \
         fakeroot \

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ export DEB_TARGET_PLATFORM ?=
 # E.g. ubuntu:22.04, ubuntu:jammy, ubuntu:bionic, etc.
 # If it is not provided, default value in Dockerfile is used
 export DEB_BUILD_DISTRIBUTION ?=
+# Ubuntu package mirror used while building the Docker image.
+# E.g. http://mirror.yandex.ru/ubuntu or http://mirror.yandex.ru/ubuntu-ports
+export DEB_BUILD_MIRROR ?=
 
 
 SRC_DIR = ch_backup

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -12,26 +12,42 @@ if (( COUNT > 1 )); then
     exit 1
 fi
 
+# Return the fingerprint of the first available secret key.
+get_secret_key_id() {
+    gpg --batch --list-secret-keys --with-colons "$@" 2>/dev/null \
+        | awk -F: '$1 == "fpr" {print $10; exit}'
+}
+
+# Use an isolated keyring for private keys supplied as data or as a file.
+setup_signing_keyring() {
+    SIGNING_GNUPGHOME=$(mktemp -d)
+    chmod 700 "${SIGNING_GNUPGHOME}"
+    export GNUPGHOME="${SIGNING_GNUPGHOME}"
+    trap 'rm -rf -- "${SIGNING_GNUPGHOME}"' EXIT
+}
+
 # Import GPG signing private key if it is provided
 if [[ -n "${DEB_SIGN_KEY_ID}" ]]; then
-    # Check if gpg knows about this key id
-    if [[ $(gpg --list-keys ${DEB_SIGN_KEY_ID} 2>&1) =~ "No public key" ]]; then
-        echo "Error: No public key ${DEB_SIGN_KEY_ID}" >&2
+    # Check that gpg has the secret part of this key.
+    KEY_ID=$(get_secret_key_id "${DEB_SIGN_KEY_ID}")
+    if [[ -z ${KEY_ID} ]]; then
+        echo "Error: No secret key ${DEB_SIGN_KEY_ID}" >&2
         exit 1
-    else
-        SIGN_ARGS="-k${DEB_SIGN_KEY_ID}"
     fi
+    SIGN_ARGS="-k${KEY_ID}"
 elif [[ -n "${DEB_SIGN_KEY}" ]]; then
-    echo "${DEB_SIGN_KEY}" | gpg --import
-    KEY_ID=$(gpg --list-keys --with-colon | awk -F: '/^fpr/ {print $10;exit}')
+    setup_signing_keyring
+    printf '%s\n' "${DEB_SIGN_KEY}" | gpg --batch --import
+    KEY_ID=$(get_secret_key_id)
     if [[ -z ${KEY_ID} ]]; then
         echo "Error: Unable to import signing key from var DEB_SIGN_KEY" >&2
         exit 1
     fi
     SIGN_ARGS="-k${KEY_ID}"
 elif [[ -n "${DEB_SIGN_KEY_PATH}" ]]; then
-    gpg --import --with-colons "${DEB_SIGN_KEY_PATH}"
-    KEY_ID=$(gpg --list-keys --with-colon | awk -F: '/^fpr/ {print $10;exit}')
+    setup_signing_keyring
+    gpg --batch --import "${DEB_SIGN_KEY_PATH}"
+    KEY_ID=$(get_secret_key_id)
     if [[ -z ${KEY_ID} ]]; then
         echo "Error: Unable to import signing key from path: ${DEB_SIGN_KEY_PATH}" >&2
         exit 1
@@ -40,6 +56,10 @@ elif [[ -n "${DEB_SIGN_KEY_PATH}" ]]; then
 else
     # Do not sign debian package
     SIGN_ARGS="-us -uc"
+fi
+
+if [[ -n "${KEY_ID}" ]]; then
+    echo "Using GPG secret key: ${KEY_ID}"
 fi
 
 # Build package

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -20,7 +20,10 @@ get_secret_key_id() {
 
 # Use an isolated keyring for private keys supplied as data or as a file.
 setup_signing_keyring() {
-    SIGNING_GNUPGHOME=$(mktemp -d)
+    SIGNING_GNUPGHOME=$(mktemp -d) || {
+        echo "Error: unable to create temporary GNUPGHOME" >&2
+        exit 1
+    }
     chmod 700 "${SIGNING_GNUPGHOME}"
     export GNUPGHOME="${SIGNING_GNUPGHOME}"
     trap 'rm -rf -- "${SIGNING_GNUPGHOME}"' EXIT

--- a/build_deb_in_docker.sh
+++ b/build_deb_in_docker.sh
@@ -15,6 +15,9 @@ if [[ -n "${DEB_BUILD_DISTRIBUTION}" ]]; then
     BUILD_ARGS+=(--build-arg BASE_IMAGE=${DEB_BUILD_DISTRIBUTION})
     BUILD_IMAGE="${BUILD_IMAGE}-${DEB_BUILD_DISTRIBUTION}"
 fi
+if [[ -n "${USE_YANDEX_MIRROR}" ]]; then
+    BUILD_ARGS+=(--build-arg USE_YANDEX_MIRROR=${USE_YANDEX_MIRROR})
+fi
 # Normalize docker image name
 BUILD_IMAGE=$(echo ${BUILD_IMAGE} | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g')
 

--- a/build_deb_in_docker.sh
+++ b/build_deb_in_docker.sh
@@ -19,7 +19,7 @@ if [[ -n "${DEB_BUILD_MIRROR}" ]]; then
     BUILD_ARGS+=(--build-arg "DEB_BUILD_MIRROR=${DEB_BUILD_MIRROR}")
 fi
 if [[ -n "${USE_YANDEX_MIRROR}" ]]; then
-    BUILD_ARGS+=(--build-arg USE_YANDEX_MIRROR=${USE_YANDEX_MIRROR})
+    BUILD_ARGS+=(--build-arg "USE_YANDEX_MIRROR=${USE_YANDEX_MIRROR}")
 fi
 # Normalize docker image name
 BUILD_IMAGE=$(echo ${BUILD_IMAGE} | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g')

--- a/build_deb_in_docker.sh
+++ b/build_deb_in_docker.sh
@@ -15,6 +15,9 @@ if [[ -n "${DEB_BUILD_DISTRIBUTION}" ]]; then
     BUILD_ARGS+=(--build-arg BASE_IMAGE=${DEB_BUILD_DISTRIBUTION})
     BUILD_IMAGE="${BUILD_IMAGE}-${DEB_BUILD_DISTRIBUTION}"
 fi
+if [[ -n "${DEB_BUILD_MIRROR}" ]]; then
+    BUILD_ARGS+=(--build-arg "DEB_BUILD_MIRROR=${DEB_BUILD_MIRROR}")
+fi
 if [[ -n "${USE_YANDEX_MIRROR}" ]]; then
     BUILD_ARGS+=(--build-arg USE_YANDEX_MIRROR=${USE_YANDEX_MIRROR})
 fi

--- a/uv.lock
+++ b/uv.lock
@@ -248,7 +248,7 @@ dev = [
     { name = "hypothesis", specifier = ">=6.131.9" },
     { name = "isort", specifier = ">=6.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
-    { name = "mypy", specifier = ">=1.10,<2.2" },
+    { name = "mypy", specifier = ">=1.10,<2.4" },
     { name = "mypy-boto3-s3", specifier = ">=1.38" },
     { name = "pyhamcrest", specifier = ">=2.1" },
     { name = "pylint", specifier = ">=3.0,<5.0" },


### PR DESCRIPTION
## Summary by Sourcery

Improve Debian package build signing and add support for configurable Ubuntu mirrors in Docker-based builds.

Enhancements:
- Harden GPG signing key handling by detecting secret keys, using an isolated temporary keyring for imported private keys, and logging the selected key fingerprint.
- Allow Docker-based Debian builds to use a configurable Ubuntu mirror and optional Yandex mirror via new build arguments and Makefile variable.