### PR TITLE
Update major version from 2 to 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ clean-test-env: stop-test-env
 
 
 ch_backup/version.txt:
-	@echo "2.$$(git rev-list HEAD --count).$$(git rev-parse --short HEAD | perl -ne 'print hex $$_')" > ch_backup/version.txt
+	@echo "3.$$(git rev-list HEAD --count).$$(git rev-parse --short HEAD | perl -ne 'print hex $$_')" > ch_backup/version.txt
 
 
 .PHONY: check-uv


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update Makefile version generation to use major version 3 instead of 2.