### PR TITLE
replace typing aliases

### DIFF
--- a/ch_backup/backup/deduplication.py
+++ b/ch_backup/backup/deduplication.py
@@ -5,7 +5,7 @@ Data part deduplication.
 from collections import defaultdict
 from copy import copy
 from datetime import timedelta
-from typing import Dict, List, Optional, Sequence, Set
+from typing import Optional, Sequence
 
 from ch_backup import logging
 from ch_backup.backup.layout import BackupLayout
@@ -79,11 +79,11 @@ class PartDedupInfo(Slotted):
         return f"('{self.database}','{self.table}','{self.name}','{self.backup_name}','{link_part_name}','{self.checksum}',{self.size},{files_array},{int(self.tarball)},'{self.disk_name}',{int(self.verified)}, {int(self.encrypted)})"
 
 
-TableDedupReferences = Set[str]
+TableDedupReferences = set[str]
 
-DatabaseDedupReferences = Dict[str, TableDedupReferences]
+DatabaseDedupReferences = dict[str, TableDedupReferences]
 
-DedupReferences = Dict[str, DatabaseDedupReferences]
+DedupReferences = dict[str, DatabaseDedupReferences]
 
 
 def _create_empty_dedup_references() -> DedupReferences:
@@ -96,7 +96,7 @@ def _create_empty_dedup_references() -> DedupReferences:
 def collect_dedup_info(
     context: BackupContext,
     databases: Sequence[Database],
-    backups_with_light_meta: List[BackupMetadata],
+    backups_with_light_meta: list[BackupMetadata],
 ) -> None:
     """
     Collect deduplication information for creating incremental backups.
@@ -147,7 +147,7 @@ class _DatabaseToHandle:
 
 def _populate_dedup_info(
     context: BackupContext,
-    dedup_backups_with_light_meta: List[BackupMetadata],
+    dedup_backups_with_light_meta: list[BackupMetadata],
     databases: Sequence[Database],
 ) -> None:
     # pylint: disable=too-many-locals,too-many-branches
@@ -269,8 +269,8 @@ def deduplicate_parts(
     context: BackupContext,
     database: str,
     table: str,
-    frozen_parts: Dict[str, FrozenPart],
-) -> Dict[str, PartMetadata]:
+    frozen_parts: dict[str, FrozenPart],
+) -> dict[str, PartMetadata]:
     """
     Deduplicate part if it's possible.
     """
@@ -279,7 +279,7 @@ def deduplicate_parts(
     existing_parts = context.ch_ctl.get_deduplication_info(
         database, table, frozen_parts
     )
-    deduplicated_parts: Dict[str, PartMetadata] = {}
+    deduplicated_parts: dict[str, PartMetadata] = {}
 
     logging.debug(
         "Deduplication lookup for {}.{}: {} frozen parts, {} matches found. First match: {}",
@@ -353,14 +353,14 @@ def deduplicate_parts(
 
 def collect_dedup_references_for_batch_backup_deletion(
     layout: BackupLayout,
-    retained_backups_light_meta: List[BackupMetadata],
-    deleting_backups_light_meta: List[BackupMetadata],
-) -> Dict[str, DedupReferences]:
+    retained_backups_light_meta: list[BackupMetadata],
+    deleting_backups_light_meta: list[BackupMetadata],
+) -> dict[str, DedupReferences]:
     """
     Collect deduplication information for deleting multiple backups. It contains names of data parts that should
     pe preserved during deletion.
     """
-    dedup_references: Dict[str, DedupReferences] = defaultdict(
+    dedup_references: dict[str, DedupReferences] = defaultdict(
         _create_empty_dedup_references
     )
 

--- a/ch_backup/backup/deduplication.py
+++ b/ch_backup/backup/deduplication.py
@@ -5,7 +5,7 @@ Data part deduplication.
 from collections import defaultdict
 from copy import copy
 from datetime import timedelta
-from typing import Optional, Sequence
+from typing import Sequence
 
 from ch_backup import logging
 from ch_backup.backup.layout import BackupLayout
@@ -55,7 +55,7 @@ class PartDedupInfo(Slotted):
         disk_name: str,
         verified: bool,
         encrypted: bool,
-        link_part_name: Optional[str] = None,
+        link_part_name: str | None = None,
     ) -> None:
         self.database = database
         self.table = table

--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -14,11 +14,9 @@ from typing import (
     BinaryIO,
     Callable,
     Iterator,
-    List,
     Literal,
     Optional,
     Sequence,
-    Union,
 )
 from urllib.parse import quote
 
@@ -183,7 +181,7 @@ class BackupLayout:
             raise StorageError(msg) from e
 
     def upload_access_control_files(
-        self, local_path: str, backup_name: str, file_names: List[str]
+        self, local_path: str, backup_name: str, file_names: list[str]
     ) -> None:
         """
         Upload access control list.
@@ -447,7 +445,7 @@ class BackupLayout:
             )
             return self._load_metadata(path, False)
 
-    def get_backups(self, use_light_meta: bool = False) -> List[BackupMetadata]:
+    def get_backups(self, use_light_meta: bool = False) -> list[BackupMetadata]:
         """
         Return list of existing backups sorted by start_time in descent order.
         """
@@ -770,7 +768,7 @@ class BackupLayout:
         backup_meta: BackupMetadata,
         disk: Disk,
         file_path: Optional[str] = None,
-    ) -> Iterator[Union[str, BinaryIO]]:
+    ) -> Iterator[str | BinaryIO]:
         """
         Opening file only once is necessary when file is actually a named pipe.
         Reader may receive EOF when file is closed, but not all metadata is downloaded.
@@ -862,7 +860,7 @@ class BackupLayout:
         if not parts:
             return
 
-        deleting_files: List[str] = []
+        deleting_files: list[str] = []
         for part in parts:
             # part.link is the source backup name for deduplicated parts (or None).
             source_backup_name = part.link or backup_meta.name

--- a/ch_backup/backup/layout.py
+++ b/ch_backup/backup/layout.py
@@ -15,7 +15,6 @@ from typing import (
     Callable,
     Iterator,
     Literal,
-    Optional,
     Sequence,
 )
 from urllib.parse import quote
@@ -340,7 +339,7 @@ class BackupLayout:
         )
         return self._storage_loader.download_data(remote_path, encryption=True)
 
-    def get_local_nc_create_statement(self, nc_name: str) -> Optional[str]:
+    def get_local_nc_create_statement(self, nc_name: str) -> str | None:
         """
         Read named collection create statement from local file.
         """
@@ -370,7 +369,7 @@ class BackupLayout:
 
     def get_local_workload_entity_create_statement(
         self, entity_name: str
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         Read workload entity create statement from local file.
         """
@@ -421,7 +420,7 @@ class BackupLayout:
 
     def get_backup(
         self, backup_name: str, use_light_meta: bool = False
-    ) -> Optional[BackupMetadata]:
+    ) -> BackupMetadata | None:
         """
         Download and return backup metadata.
         """
@@ -767,7 +766,7 @@ class BackupLayout:
         self,
         backup_meta: BackupMetadata,
         disk: Disk,
-        file_path: Optional[str] = None,
+        file_path: str | None = None,
     ) -> Iterator[str | BinaryIO]:
         """
         Opening file only once is necessary when file is actually a named pipe.
@@ -799,7 +798,7 @@ class BackupLayout:
         disk: Disk,
         source_disk_name: str,
         desired_tables: Sequence[TableMetadata] | Literal["all"],
-        file_path: Optional[str] = None,
+        file_path: str | None = None,
     ) -> None:
         """
         Download files packed in tarball and unpacks them into specified directory.
@@ -1021,8 +1020,8 @@ def _part_path(
 
 def _disk_metadata_path(
     backup_path: str,
-    db_name: Optional[str],
-    table_name: Optional[str],
+    db_name: str | None,
+    table_name: str | None,
     disk_name: str,
     compressed: bool = False,
 ) -> str:

--- a/ch_backup/backup/metadata/access_control_metadata.py
+++ b/ch_backup/backup/metadata/access_control_metadata.py
@@ -3,7 +3,7 @@ Access control metadata.
 """
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Sequence
+from typing import Any, Sequence
 
 from ch_backup.backup.metadata.common import BackupStorageFormat
 from ch_backup.util import dataclass_from_dict
@@ -15,8 +15,8 @@ class AccessControlMetadata:
     Access control metadata.
     """
 
-    acl_ids: List[str] = field(default_factory=list)
-    acl_meta: Dict[str, Any] = field(default_factory=dict)
+    acl_ids: list[str] = field(default_factory=list)
+    acl_meta: dict[str, Any] = field(default_factory=dict)
     backup_format: BackupStorageFormat = BackupStorageFormat.TAR
 
     def __post_init__(self) -> None:
@@ -24,7 +24,7 @@ class AccessControlMetadata:
 
     @classmethod
     def from_ch_objects(
-        cls, objects: Sequence[Dict[str, Any]]
+        cls, objects: Sequence[dict[str, Any]]
     ) -> "AccessControlMetadata":
         """
         Create Access Control metadata from objects fetched from ClickHouse.
@@ -37,13 +37,13 @@ class AccessControlMetadata:
         return cls(acl_ids, acl_meta)
 
     @classmethod
-    def load(cls, data: Dict[str, Any]) -> "AccessControlMetadata":
+    def load(cls, data: dict[str, Any]) -> "AccessControlMetadata":
         """
         Deserialize Access Control metadata.
         """
         return dataclass_from_dict(cls, data)
 
-    def dump(self) -> Dict[str, Any]:
+    def dump(self) -> dict[str, Any]:
         """
         Serialize Access Control metadata.
         """

--- a/ch_backup/backup/metadata/backup_metadata.py
+++ b/ch_backup/backup/metadata/backup_metadata.py
@@ -8,7 +8,7 @@ import os
 import socket
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Optional, Sequence
+from typing import Any, Sequence
 
 from ch_backup.backup.metadata.access_control_metadata import AccessControlMetadata
 from ch_backup.backup.metadata.cloud_storage_metadata import CloudStorageMetadata
@@ -99,14 +99,14 @@ class BackupMetadata:
         self._state = value
 
     @property
-    def exception(self) -> Optional[str]:
+    def exception(self) -> str | None:
         """
         Exception type and message for failed backup.
         """
         return self._exception
 
     @exception.setter
-    def exception(self, value: Optional[str]) -> None:
+    def exception(self, value: str | None) -> None:
         self._exception = value
 
     @property
@@ -117,7 +117,7 @@ class BackupMetadata:
         return self._format_time(self.start_time)
 
     @property
-    def end_time_str(self) -> Optional[str]:
+    def end_time_str(self) -> str | None:
         """
         String representation of backup end time.
         """
@@ -207,8 +207,8 @@ class BackupMetadata:
         self,
         light: bool = False,
         pretty: bool = False,
-        database: Optional[str] = None,
-        table: Optional[str] = None,
+        database: str | None = None,
+        table: str | None = None,
     ) -> str:
         """
         Return json representation of backup metadata.
@@ -373,7 +373,7 @@ class BackupMetadata:
             "tables": {},
         }
 
-    def get_tables(self, db_name: Optional[str] = None) -> Sequence[TableMetadata]:
+    def get_tables(self, db_name: str | None = None) -> Sequence[TableMetadata]:
         """
         Get tables for the specified database.
         """
@@ -460,7 +460,7 @@ class BackupMetadata:
 
     def find_part(
         self, db_name: str, table_name: str, part_name: str
-    ) -> Optional[PartMetadata]:
+    ) -> PartMetadata | None:
         """
         Find and return data part. If not found, None is returned.
         """

--- a/ch_backup/backup/metadata/backup_metadata.py
+++ b/ch_backup/backup/metadata/backup_metadata.py
@@ -8,7 +8,7 @@ import os
 import socket
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Optional, Sequence
 
 from ch_backup.backup.metadata.access_control_metadata import AccessControlMetadata
 from ch_backup.backup.metadata.cloud_storage_metadata import CloudStorageMetadata
@@ -50,7 +50,7 @@ class BackupMetadata:
         labels: dict = None,
         schema_only: bool = False,
         encrypted: bool = True,
-        path: Optional[str] = None,
+        path: str | None = None,
     ) -> None:
         self.name = name
         # DEPRECATED: ``path`` is kept solely for backward compatibility with
@@ -67,7 +67,7 @@ class BackupMetadata:
         self.labels = labels or {}
         self.time_format = time_format
         self.start_time = now()
-        self.end_time: Optional[datetime] = None
+        self.end_time: datetime | None = None
         self.size = 0
         self.real_size = 0
         self.schema_only = schema_only
@@ -75,12 +75,12 @@ class BackupMetadata:
         self.cloud_storage: CloudStorageMetadata = CloudStorageMetadata()
 
         self._state = BackupState.CREATING
-        self._exception: Optional[str] = None
-        self._databases: Dict[str, dict] = {}
+        self._exception: str | None = None
+        self._databases: dict[str, dict] = {}
         self._access_control = AccessControlMetadata()
-        self._user_defined_functions: List[str] = []
-        self._named_collections: List[str] = []
-        self._workload_entities: List[str] = []
+        self._user_defined_functions: list[str] = []
+        self._named_collections: list[str] = []
+        self._workload_entities: list[str] = []
 
     def __str__(self) -> str:
         return self.dump_json()
@@ -134,7 +134,7 @@ class BackupMetadata:
         Serialize backup metadata.
         """
         if light:
-            databases: Dict[str, dict] = {}
+            databases: dict[str, dict] = {}
         else:
             # Rewrite ``link`` of every part from a plain backup name back to a
             # full storage path (``<path_root>/<source_backup_name>``) so that
@@ -174,7 +174,7 @@ class BackupMetadata:
             },
         }
 
-    def _databases_with_legacy_part_links(self) -> Dict[str, dict]:
+    def _databases_with_legacy_part_links(self) -> dict[str, dict]:
         """
         Return a deep-copy of ``self._databases`` where every part's ``link``
         field is rewritten from a plain backup name (new format) to a full
@@ -422,7 +422,7 @@ class BackupMetadata:
         assert nc_name not in self._named_collections
         self._named_collections.append(nc_name)
 
-    def get_udf(self) -> List[str]:
+    def get_udf(self) -> list[str]:
         """
         Get user defined function data.
         """
@@ -432,14 +432,14 @@ class BackupMetadata:
         """
         Get data parts of all tables.
         """
-        parts: List[PartMetadata] = []
+        parts: list[PartMetadata] = []
         for db_name in self.get_databases():
             for table in self.get_tables(db_name):
                 parts.extend(table.get_parts())
 
         return parts
 
-    def get_named_collections(self) -> List[str]:
+    def get_named_collections(self) -> list[str]:
         """
         Get named collections data.
         """
@@ -452,7 +452,7 @@ class BackupMetadata:
         assert entity_name not in self._workload_entities
         self._workload_entities.append(entity_name)
 
-    def get_workload_entities(self) -> List[str]:
+    def get_workload_entities(self) -> list[str]:
         """
         Get workload entities data.
         """
@@ -480,7 +480,7 @@ class BackupMetadata:
         if not part.link:
             self.real_size += part.size
 
-    def remove_parts(self, table: TableMetadata, parts: List[PartMetadata]) -> None:
+    def remove_parts(self, table: TableMetadata, parts: list[PartMetadata]) -> None:
         """
         Remove data parts from backup metadata.
         """
@@ -506,7 +506,7 @@ class BackupMetadata:
         """
         return self._access_control
 
-    def set_access_control(self, objects: Sequence[Dict[str, Any]]) -> None:
+    def set_access_control(self, objects: Sequence[dict[str, Any]]) -> None:
         """
         Build and add access control objects to backup metadata.
         """
@@ -523,7 +523,7 @@ class BackupMetadata:
         return value.strftime(self.time_format)
 
     @staticmethod
-    def _load_time(meta: dict, attr: str) -> Optional[datetime]:
+    def _load_time(meta: dict, attr: str) -> datetime | None:
         attr_value = meta.get(attr)
         if not attr_value:
             return None

--- a/ch_backup/backup/metadata/cloud_storage_metadata.py
+++ b/ch_backup/backup/metadata/cloud_storage_metadata.py
@@ -2,7 +2,7 @@
 Backup metadata for Cloud Storage.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 
 class CloudStorageMetadata:
@@ -14,11 +14,11 @@ class CloudStorageMetadata:
         self,
         encryption: bool = True,
         compression: bool = True,
-        disks: Optional[List[str]] = None,
+        disks: list[str] | None = None,
     ) -> None:
         self._encryption: bool = encryption
         self._compression: bool = compression
-        self._disks: List[str] = disks or []
+        self._disks: list[str] = disks or []
 
     @property
     def enabled(self) -> bool:
@@ -28,7 +28,7 @@ class CloudStorageMetadata:
         return len(self._disks) > 0
 
     @property
-    def disks(self) -> List[str]:
+    def disks(self) -> list[str]:
         """
         Return list of backed up disks names.
         """
@@ -68,7 +68,7 @@ class CloudStorageMetadata:
         self._compression = True
 
     @classmethod
-    def load(cls, data: Dict[str, Any]) -> "CloudStorageMetadata":
+    def load(cls, data: dict[str, Any]) -> "CloudStorageMetadata":
         """
         Deserialize Cloud Storage metadata.
         """
@@ -78,7 +78,7 @@ class CloudStorageMetadata:
             disks=data.get("disks", []),
         )
 
-    def dump(self) -> Dict[str, Any]:
+    def dump(self) -> dict[str, Any]:
         """
         Serialize Cloud Storage metadata.
         """

--- a/ch_backup/backup/metadata/part_metadata.py
+++ b/ch_backup/backup/metadata/part_metadata.py
@@ -3,13 +3,13 @@ Backup metadata for ClickHouse data part.
 """
 
 import os
-from typing import Optional, Sequence
+from typing import Sequence
 
 from ch_backup.clickhouse.models import FrozenPart
 from ch_backup.util import Slotted
 
 
-def normalize_backup_link(raw_link: Optional[str]) -> Optional[str]:
+def normalize_backup_link(raw_link: str | None) -> str | None:
     """
     Normalize the ``link`` field to a plain backup name.
 
@@ -53,9 +53,9 @@ class RawMetadata(Slotted):
         size: int,
         files: Sequence[str],
         tarball: bool,
-        link: Optional[str] = None,
-        link_part_name: Optional[str] = None,
-        disk_name: Optional[str] = None,
+        link: str | None = None,
+        link_part_name: str | None = None,
+        disk_name: str | None = None,
         encrypted: bool = True,
     ) -> None:
         self.checksum = checksum
@@ -85,9 +85,9 @@ class PartMetadata(Slotted):
         size: int,
         files: Sequence[str],
         tarball: bool,
-        link: Optional[str] = None,
-        link_part_name: Optional[str] = None,
-        disk_name: Optional[str] = None,
+        link: str | None = None,
+        link_part_name: str | None = None,
+        disk_name: str | None = None,
         encrypted: bool = True,
     ) -> None:
         self.database: str = database
@@ -119,7 +119,7 @@ class PartMetadata(Slotted):
         return self.raw_metadata.files
 
     @property
-    def link(self) -> Optional[str]:
+    def link(self) -> str | None:
         """
         For deduplicated data parts returns the name of the source backup.
         For non-deduplicated parts returns None.
@@ -127,7 +127,7 @@ class PartMetadata(Slotted):
         return self.raw_metadata.link
 
     @property
-    def link_part_name(self) -> Optional[str]:
+    def link_part_name(self) -> str | None:
         """
         For deduplicated data parts returns the name of the source part in backup.
         For non-deduplicated parts returns None.

--- a/ch_backup/backup/metadata/table_metadata.py
+++ b/ch_backup/backup/metadata/table_metadata.py
@@ -3,7 +3,7 @@ Backup metadata for ClickHouse table.
 """
 
 from types import SimpleNamespace
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 from ch_backup.backup.metadata.part_metadata import PartMetadata
 
@@ -55,9 +55,7 @@ class TableMetadata(SimpleNamespace):
     Backup metadata for ClickHouse table.
     """
 
-    def __init__(
-        self, database: str, name: str, engine: str, uuid: Optional[str]
-    ) -> None:
+    def __init__(self, database: str, name: str, engine: str, uuid: str | None) -> None:
         super().__init__()
         self.database: str = database
         self.name: str = name
@@ -75,7 +73,7 @@ class TableMetadata(SimpleNamespace):
         return self.raw_metadata["engine"]
 
     @property
-    def uuid(self) -> Optional[str]:
+    def uuid(self) -> str | None:
         """
         Return uuid of the table if not zero. Used for view restore in ch > 20.10
         """

--- a/ch_backup/backup/metadata/table_metadata.py
+++ b/ch_backup/backup/metadata/table_metadata.py
@@ -3,7 +3,7 @@ Backup metadata for ClickHouse table.
 """
 
 from types import SimpleNamespace
-from typing import List, NamedTuple, Optional, Set
+from typing import NamedTuple, Optional
 
 from ch_backup.backup.metadata.part_metadata import PartMetadata
 
@@ -81,7 +81,7 @@ class TableMetadata(SimpleNamespace):
         """
         return self.raw_metadata["uuid"]
 
-    def get_parts(self, *, excluded_parts: Set[str] = None) -> List[PartMetadata]:
+    def get_parts(self, *, excluded_parts: set[str] = None) -> list[PartMetadata]:
         """
         Return data parts (sorted).
         """

--- a/ch_backup/backup/restore_context.py
+++ b/ch_backup/backup/restore_context.py
@@ -6,7 +6,7 @@ import json
 from collections import defaultdict
 from enum import Enum
 from os.path import exists
-from typing import Any, Callable, Dict, Mapping
+from typing import Any, Callable, Mapping
 
 from ch_backup.backup.metadata import PartMetadata
 
@@ -27,12 +27,12 @@ class RestoreContext:
     Backup restore context. Allows continue restore process after errors.
     """
 
-    def __init__(self, config: Dict):
+    def __init__(self, config: dict):
         self._state_file = config["restore_context_path"]
         self._state_file_dump_threshold = config["restore_context_sync_threshold_ops"]
         self._state_updates_cnt = 0
 
-        self._databases_dict: Dict[str, Dict[str, Dict[str, PartState]]] = defaultdict(
+        self._databases_dict: dict[str, dict[str, dict[str, PartState]]] = defaultdict(
             lambda: defaultdict(lambda: defaultdict(lambda: PartState.NOT_DOWNLOADED))
         )
         self._failed: Mapping[str, Any] = defaultdict(
@@ -58,7 +58,7 @@ class RestoreContext:
         return wrapper
 
     @property
-    def _databases(self) -> Dict[str, Dict[str, Dict[str, PartState]]]:
+    def _databases(self) -> dict[str, dict[str, dict[str, PartState]]]:
         """
         Databases property with lazy load.
         """
@@ -68,7 +68,7 @@ class RestoreContext:
         return self._databases_dict
 
     @_databases.setter
-    def _databases(self, databases: Dict[str, Dict[str, Dict[str, PartState]]]) -> None:
+    def _databases(self, databases: dict[str, dict[str, dict[str, PartState]]]) -> None:
         """
         Databases property setter.
         """
@@ -134,8 +134,8 @@ class RestoreContext:
 
     def _load_state(self) -> None:
         with open(self._state_file, "r", encoding="utf-8") as f:
-            state: Dict[str, Any] = json.load(f)
-            databases: Dict[str, Dict[str, Dict[str, PartState]]] = defaultdict(
+            state: dict[str, Any] = json.load(f)
+            databases: dict[str, dict[str, dict[str, PartState]]] = defaultdict(
                 lambda: defaultdict(
                     lambda: defaultdict(lambda: PartState.NOT_DOWNLOADED)
                 )

--- a/ch_backup/calculators.py
+++ b/ch_backup/calculators.py
@@ -5,13 +5,13 @@ Auxiliary functions for calculation sizes of backped data blocks.
 import math
 from pathlib import Path
 from tarfile import BLOCKSIZE, LENGTH_NAME
-from typing import Iterable, List, Optional
+from typing import Iterable
 
 from ch_backup.util import scan_dir_files
 
 
 def calc_aligned_files_size_scan(
-    base_path: Path, exclude_file_names: Optional[List[str]] = None, alignment: int = 1
+    base_path: Path, exclude_file_names: list[str] | None = None, alignment: int = 1
 ) -> int:
     """
     Calculate total size of files on disk with padding added after each file.
@@ -27,7 +27,7 @@ def calc_aligned_files_size_scan(
     return size
 
 
-def calc_aligned_files_size(files: List[Path], alignment: int = 1) -> int:
+def calc_aligned_files_size(files: list[Path], alignment: int = 1) -> int:
     """
     Calculate total size of files on disk with padding added after each file.
     """
@@ -41,7 +41,7 @@ def calc_aligned_files_size(files: List[Path], alignment: int = 1) -> int:
     return size
 
 
-def calc_aligned_data_size(data_list: List[bytes], alignment: int = 1) -> int:
+def calc_aligned_data_size(data_list: list[bytes], alignment: int = 1) -> int:
     """
     Calculate total size of data with padding added after each element.
     """
@@ -58,7 +58,7 @@ def calc_aligned_data_size(data_list: List[bytes], alignment: int = 1) -> int:
 def calc_tarball_size_scan(
     dir_path: Path,
     aligned_files_size: int,
-    exclude_file_names: Optional[List[str]] = None,
+    exclude_file_names: list[str] | None = None,
 ) -> int:
     """
     Calculate tarball (TAR archive) size.

--- a/ch_backup/ch_backup.py
+++ b/ch_backup/ch_backup.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from copy import copy
 from datetime import timedelta
 from enum import Enum
-from typing import Dict, List, Optional, Sequence, Set, Tuple
+from typing import List, Sequence
 
 from ch_backup import logging
 from ch_backup.backup.deduplication import (
@@ -116,7 +116,7 @@ class ClickhouseBackup:
         tables: Sequence[str] = None,
         force: bool = False,
         labels: dict = None,
-    ) -> Tuple[str, Optional[str]]:
+    ) -> tuple[str, str | None]:
         """
         Perform backup.
 
@@ -140,7 +140,7 @@ class ClickhouseBackup:
         if labels:
             backup_labels.update(labels)
 
-        db_tables: Dict[str, list] = defaultdict(list)
+        db_tables: dict[str, list] = defaultdict(list)
         if tables:
             for table in tables or []:
                 db_name, table_name = table.split(".", 1)
@@ -238,7 +238,7 @@ class ClickhouseBackup:
         exclude_databases: Sequence[str],
         override_replica_name: str = None,
         force_non_replicated: bool = False,
-        replica_name: Optional[str] = None,
+        replica_name: str | None = None,
         cloud_storage_source_bucket: str = None,
         cloud_storage_source_path: str = None,
         cloud_storage_source_endpoint: str = None,
@@ -246,7 +246,7 @@ class ClickhouseBackup:
         clean_zookeeper_mode: CleanZooKeeperMode = CleanZooKeeperMode.DISABLED,
         keep_going: bool = False,
         restore_tables_in_replicated_database: bool = False,
-        partial_restore_filter: Optional[PartialRestoreFilter] = None,
+        partial_restore_filter: PartialRestoreFilter | None = None,
     ) -> None:
         """
         Restore specified backup
@@ -343,7 +343,7 @@ class ClickhouseBackup:
 
     def delete(
         self, backup_name: str, purge_partial: bool
-    ) -> Tuple[Optional[str], Optional[str]]:
+    ) -> tuple[str | None, str | None]:
         """
         Delete the specified backup.
         """
@@ -374,7 +374,7 @@ class ClickhouseBackup:
                 deleting_backups_light_meta=deleting_backups,
             )
 
-            result: Tuple[Optional[str], Optional[str]] = (None, None)
+            result: tuple[str | None, str | None] = (None, None)
             for backup in deleting_backups:
                 deleted_name, msg = self._delete(backup, dedup_references[backup.name])
                 if backup_name == backup.name:
@@ -382,7 +382,7 @@ class ClickhouseBackup:
 
         return result
 
-    def purge(self) -> Tuple[Sequence[str], Optional[str]]:
+    def purge(self) -> tuple[Sequence[str], str | None]:
         """
         Purge backups.
         """
@@ -461,7 +461,7 @@ class ClickhouseBackup:
         self,
         backup_name: str,
         disk_name: str,
-        local_path: Optional[str] = None,
+        local_path: str | None = None,
     ) -> bool:
         """Download cloud storage metadata to shadow directory or to a file at given path. Returns false if metadata is already present."""
         backup_meta = self._get_backup(backup_name)
@@ -484,7 +484,7 @@ class ClickhouseBackup:
 
     def _delete(
         self, backup_light_meta: BackupMetadata, dedup_references: DedupReferences
-    ) -> Tuple[Optional[str], Optional[str]]:
+    ) -> tuple[str | None, str | None]:
         logging.info(
             "Deleting backup %s, state: %s",
             backup_light_meta.name,
@@ -535,7 +535,7 @@ class ClickhouseBackup:
         self,
         backup: BackupMetadata,
         table: TableMetadata,
-        excluded_parts: Set[str] = None,
+        excluded_parts: set[str] = None,
     ) -> None:
         parts = table.get_parts(excluded_parts=excluded_parts)
         own_parts = [part for part in parts if not part.link]
@@ -548,10 +548,10 @@ class ClickhouseBackup:
         sources: BackupSources,
         db_names: Sequence[str],
         tables: List[TableMetadata],
-        replica_name: Optional[str] = None,
-        cloud_storage_source_bucket: Optional[str] = None,
-        cloud_storage_source_path: Optional[str] = None,
-        cloud_storage_source_endpoint: Optional[str] = None,
+        replica_name: str | None = None,
+        cloud_storage_source_bucket: str | None = None,
+        cloud_storage_source_path: str | None = None,
+        cloud_storage_source_endpoint: str | None = None,
         skip_cloud_storage: bool = False,
         clean_zookeeper_mode: CleanZooKeeperMode = CleanZooKeeperMode.DISABLED,
         keep_going: bool = False,
@@ -576,12 +576,12 @@ class ClickhouseBackup:
             self._we_backup_manager.restore(self._context)
 
         if sources.schemas_included():
-            databases: Dict[str, Database] = {
+            databases: dict[str, Database] = {
                 db_name: self._context.backup_meta.get_database(db_name)
                 for db_name in db_names
             }
 
-            metadata_cleaner: Optional[MetadataCleaner] = None
+            metadata_cleaner: MetadataCleaner | None = None
 
             if (
                 clean_zookeeper_mode != CleanZooKeeperMode.DISABLED

--- a/ch_backup/ch_backup.py
+++ b/ch_backup/ch_backup.py
@@ -2,11 +2,12 @@
 Clickhouse backup logic
 """
 
+import builtins
 from collections import defaultdict
 from copy import copy
 from datetime import timedelta
 from enum import Enum
-from typing import List, Sequence
+from typing import Sequence
 
 from ch_backup import logging
 from ch_backup.backup.deduplication import (
@@ -302,7 +303,7 @@ class ClickhouseBackup:
         tables = []
         if partial_restore_filter:
             excluded_tables = []
-            all_tables: List[TableMetadata] = []
+            all_tables: list[TableMetadata] = []
             for db_name in databases:
                 all_tables.extend(self._context.backup_meta.get_tables(db_name))
             for table in all_tables:
@@ -389,7 +390,7 @@ class ClickhouseBackup:
         retain_time = self._context.config["retain_time"]
         retain_count = self._context.config["retain_count"]
 
-        deleted_backup_names: List[str] = []
+        deleted_backup_names: list[str] = []
 
         if not retain_time and retain_count is None:
             logging.info("Retain policies are not specified")
@@ -399,8 +400,8 @@ class ClickhouseBackup:
         if retain_time:
             retain_time_limit = now() - timedelta(**retain_time)
 
-        retained_backups: List[BackupMetadata] = []
-        deleting_backups: List[BackupMetadata] = []
+        retained_backups: list[BackupMetadata] = []
+        deleting_backups: list[BackupMetadata] = []
         backup_names = self._context.backup_layout.get_backup_names()
 
         with self._context.locker(operation="PURGE"):
@@ -547,7 +548,7 @@ class ClickhouseBackup:
         self,
         sources: BackupSources,
         db_names: Sequence[str],
-        tables: List[TableMetadata],
+        tables: builtins.list[TableMetadata],
         replica_name: str | None = None,
         cloud_storage_source_bucket: str | None = None,
         cloud_storage_source_path: str | None = None,

--- a/ch_backup/cli.py
+++ b/ch_backup/cli.py
@@ -12,7 +12,7 @@ import uuid
 from collections import OrderedDict
 from functools import wraps
 from pathlib import Path as PathlibPath
-from typing import Iterable, Optional, Tuple, Union
+from typing import Iterable
 
 from click import Choice, Path, argument, pass_context, style
 from cloup import (
@@ -123,10 +123,10 @@ def cli(
     protocol: str,
     host: str,
     port: int,
-    ca_path: Union[str, bool],
+    ca_path: str | bool,
     insecure: bool,
     zk_hosts: str,
-    config_parameters: Iterable[Tuple[str, dict]],
+    config_parameters: Iterable[tuple[str, dict]],
 ) -> None:
     """Tool for managing ClickHouse backups."""
     if insecure:
@@ -286,8 +286,8 @@ def show_command(
     ch_backup: ClickhouseBackup,
     name: str,
     pretty: bool,
-    database: Optional[str],
-    table: Optional[str],
+    database: str | None,
+    table: str | None,
 ) -> None:
     """Show details for a particular backup."""
     name = _validate_and_resolve_name(ctx, ch_backup, name)
@@ -380,9 +380,9 @@ def show_command(
             d=style(
                 '"{}"'.format(
                     format_timespan(
-                        typing.cast(
-                            typing.Dict[str, dict], DEFAULT_CONFIG["clickhouse"]
-                        )["freeze_timeout"]
+                        typing.cast(dict[str, dict], DEFAULT_CONFIG["clickhouse"])[
+                            "freeze_timeout"
+                        ]
                     )
                 ),
                 fg=Color.cyan,
@@ -604,8 +604,8 @@ def restore_command(
     data: bool = False,
     schema: bool = False,
     udf: bool = False,
-    table_included_patterns: Optional[typing.List[str]] = None,
-    table_excluded_patterns: Optional[typing.List[str]] = None,
+    table_included_patterns: list[str] | None = None,
+    table_excluded_patterns: list[str] | None = None,
     nc: bool = False,
     workload: bool = False,
 ) -> None:
@@ -613,8 +613,8 @@ def restore_command(
     # pylint: disable=too-many-arguments,too-many-locals
     name = _validate_and_resolve_name(ctx, ch_backup, name)
 
-    specified_databases: typing.List[str] = _list_to_database_names(databases)
-    excluded_databases: typing.List[str] = _list_to_database_names(exclude_databases)
+    specified_databases: list[str] = _list_to_database_names(databases)
+    excluded_databases: list[str] = _list_to_database_names(exclude_databases)
 
     matcher = None
     if table_included_patterns:
@@ -775,7 +775,7 @@ def _validate_and_resolve_name(
     return name
 
 
-def _list_to_database_names(dbs: typing.Optional[typing.List[str]]) -> typing.List[str]:
+def _list_to_database_names(dbs: list[str] | None) -> list[str]:
     if not dbs:
         return []
 
@@ -783,9 +783,9 @@ def _list_to_database_names(dbs: typing.Optional[typing.List[str]]) -> typing.Li
 
 
 def _key_values_to_tables_metadata(
-    kvs: typing.Optional[KeyValues],
-) -> typing.List[TableMetadata]:
-    result: typing.List[TableMetadata] = []
+    kvs: KeyValues | None,
+) -> list[TableMetadata]:
+    result: list[TableMetadata] = []
 
     if not kvs:
         return result
@@ -797,13 +797,13 @@ def _key_values_to_tables_metadata(
     return result
 
 
-def _build_cli_cfg_from_config_parameters(values: Iterable[Tuple[str, dict]]) -> dict:
+def _build_cli_cfg_from_config_parameters(values: Iterable[tuple[str, dict]]) -> dict:
     """
     Build config dict from specified keys and values in plain format.
     Duplicate keys are ignored in favor of the last entry.
     """
 
-    def _split_key(key: str) -> typing.List[str]:
+    def _split_key(key: str) -> list[str]:
         return key.split(".")
 
     values_by_uniq_key: dict[str, dict] = {}

--- a/ch_backup/clickhouse/client.py
+++ b/ch_backup/clickhouse/client.py
@@ -3,7 +3,7 @@ ClickHouse client.
 """
 
 from contextlib import contextmanager
-from typing import Any, Iterator, Optional, Union
+from typing import Any, Iterator
 
 import requests
 
@@ -56,7 +56,7 @@ class ClickhouseClient:
     # pylint: disable=too-many-positional-arguments
     def query(
         self,
-        query: Union[bytes, str],
+        query: bytes | str,
         post_data: dict = None,
         settings: dict = None,
         timeout: float = None,
@@ -102,7 +102,7 @@ class ClickhouseClient:
 
     @contextmanager
     def _get_session(
-        self, new_session: Optional[bool] = False
+        self, new_session: bool | None = False
     ) -> Iterator[requests.Session]:
         session = (
             self._create_session(self._config, self._settings)

--- a/ch_backup/clickhouse/config.py
+++ b/ch_backup/clickhouse/config.py
@@ -2,7 +2,7 @@
 Module for working with Clickhouse configuration file.
 """
 
-from typing import Any, Dict
+from typing import Any
 
 import xmltodict
 
@@ -15,7 +15,7 @@ class ClickhouseConfig:
     """
 
     def __init__(self, config: Config) -> None:
-        self._ch_config: Dict[str, Any] = {}
+        self._ch_config: dict[str, Any] = {}
         self._ch_config_path = config["clickhouse"]["preprocessed_config_path"]
 
     def load(self) -> None:

--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager, suppress
 from hashlib import md5
 from pathlib import Path
 from tarfile import BLOCKSIZE  # type: ignore
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Iterable, Sequence
 
 from ch_backup import logging
 from ch_backup.backup.metadata import TableMetadata
@@ -656,7 +656,7 @@ class ClickhouseCTL:
 
         self._ch_client.query(query_sql)
 
-    def attach_table(self, table: Union[TableMetadata, Table]) -> None:
+    def attach_table(self, table: TableMetadata | Table) -> None:
         """
         Attach data part to the specified table.
         """
@@ -699,7 +699,7 @@ class ClickhouseCTL:
             and "PARTITION BY" in table.create_statement
         )
 
-        query_settings: Dict[str, Any] = {"max_threads": 1}
+        query_settings: dict[str, Any] = {"max_threads": 1}
 
         # Since https://github.com/ClickHouse/ClickHouse/pull/75016
         if self.ch_version_ge("25.2"):
@@ -751,7 +751,7 @@ class ClickhouseCTL:
             new_session=True,
         )
 
-    def list_partitions(self, table: Table) -> List[str]:
+    def list_partitions(self, table: Table) -> list[str]:
         """
         Get list of active partitions for table.
         """
@@ -771,7 +771,7 @@ class ClickhouseCTL:
             self._ch_client.query(query_sql, timeout=self._unfreeze_timeout)
 
     def remove_freezed_data(
-        self, backup_name: Optional[str] = None, table: Optional[Table] = None
+        self, backup_name: str | None = None, table: Table | None = None
     ) -> None:
         """
         Remove all freezed partitions from all local disks.
@@ -805,7 +805,7 @@ class ClickhouseCTL:
         self._remove_shadow_data(part.path)
 
     def get_databases(
-        self, exclude_dbs: Optional[Sequence[str]] = None
+        self, exclude_dbs: Sequence[str] | None = None
     ) -> Sequence[Database]:
         """
         Get list of all databases.
@@ -813,7 +813,7 @@ class ClickhouseCTL:
         if not exclude_dbs:
             exclude_dbs = []
 
-        result: List[Database] = []
+        result: list[Database] = []
         system_database = self._backup_config["system_database"]
 
         query = (
@@ -855,7 +855,7 @@ class ClickhouseCTL:
     def get_tables(
         self,
         db_name: str = None,
-        tables: Optional[Sequence[str]] = None,
+        tables: Sequence[str] | None = None,
         short_query: bool = False,
     ) -> Sequence[Table]:
         """
@@ -883,7 +883,7 @@ class ClickhouseCTL:
             db_condition=db_condition,
             tables_condition=tables_condition,
         )
-        result: List[Table] = []
+        result: list[Table] = []
         for row in self._ch_client.query(query_sql)["data"]:
             result.append(self._make_table(row))
 
@@ -912,7 +912,7 @@ class ClickhouseCTL:
         """
         Get detached tables.
         """
-        result: List[Table] = []
+        result: list[Table] = []
 
         if not self.ch_version_ge("24.8"):
             logging.warning(
@@ -930,7 +930,7 @@ class ClickhouseCTL:
 
     def get_table(
         self, db_name: str, table_name: str, short_query: bool = False
-    ) -> Optional[Table]:
+    ) -> Table | None:
         """
         Get table by name, returns None if no table has found.
         """
@@ -945,9 +945,9 @@ class ClickhouseCTL:
 
     def get_replicas(
         self,
-        db_name: Optional[str] = None,
+        db_name: str | None = None,
         tables: Sequence[str] = None,
-        readonly: Optional[bool] = None,
+        readonly: bool | None = None,
     ) -> list[dict]:
         """
         Get table replicas from system.replicas
@@ -1103,7 +1103,7 @@ class ClickhouseCTL:
             timeout=self._drop_replica_timeout,
         )
 
-    def get_ddl_queue_unfinished_status(self, db_name: str) -> List[Dict]:
+    def get_ddl_queue_unfinished_status(self, db_name: str) -> list[dict]:
         """
         Get pending DDL entries from system.distributed_ddl_queue for a replicated database.
         Returns list of entries with status, exception_code and exception_text.
@@ -1144,11 +1144,11 @@ class ClickhouseCTL:
         """
         return self._ch_version
 
-    def get_access_control_objects(self) -> Sequence[Dict[str, Any]]:
+    def get_access_control_objects(self) -> Sequence[dict[str, Any]]:
         """
         Returns all access control objects.
         """
-        result: List[Dict[str, Any]] = []
+        result: list[dict[str, Any]] = []
 
         for obj_type, obj_char in ACCESS_ENTITY_CHAR.items():
             ch_resp = self._ch_client.query(
@@ -1169,7 +1169,7 @@ class ClickhouseCTL:
         assert len(result) == 1
         return result[0]["value"]
 
-    def get_zookeeper_admin_uuid(self) -> Dict[str, str]:
+    def get_zookeeper_admin_uuid(self) -> dict[str, str]:
         """
         Returns all UUIDs associated with admin user.
         """
@@ -1291,28 +1291,28 @@ class ClickhouseCTL:
         """
         return _parse_version(self.get_version()) >= _parse_version(comparing_version)
 
-    def get_macros(self) -> Dict:
+    def get_macros(self) -> dict:
         """
         Get ClickHouse macros.
         """
         ch_resp = self._ch_client.query(GET_MACROS_SQL)
         return {row["macro"]: row["substitution"] for row in ch_resp.get("data", [])}
 
-    def get_udf_query(self) -> Dict[str, str]:
+    def get_udf_query(self) -> dict[str, str]:
         """
         Get udf query from system table.
         """
         resp = self._ch_client.query(GET_UDF_QUERY_SQL)
         return {row["name"]: row["create_query"] for row in resp.get("data", [])}
 
-    def get_named_collections_query(self) -> List[str]:
+    def get_named_collections_query(self) -> list[str]:
         """
         Get named collections query from system table.
         """
         resp = self._ch_client.query(GET_NAMED_COLLECTIONS_QUERY_SQL)
         return [row["name"] for row in resp.get("data", [])]
 
-    def get_workload_entities_query(self) -> List[Tuple[str, WorkloadEntityType]]:
+    def get_workload_entities_query(self) -> list[tuple[str, WorkloadEntityType]]:
         """
         Get workload entities (WORKLOADs and RESOURCEs) from system tables.
         """
@@ -1372,7 +1372,7 @@ class ClickhouseCTL:
             resp.get("cache_path"),
         )
 
-    def get_disks(self) -> Dict[str, Disk]:
+    def get_disks(self) -> dict[str, Disk]:
         """
         Get all configured disks.
         """
@@ -1434,7 +1434,7 @@ class ClickhouseCTL:
 
         return metadata_path
 
-    def read_s3_disk_revision(self, disk_name: str, backup_name: str) -> Optional[int]:
+    def read_s3_disk_revision(self, disk_name: str, backup_name: str) -> int | None:
         """
         Reads S3 disk revision counter.
         """
@@ -1474,7 +1474,7 @@ class ClickhouseCTL:
             )
         )
 
-    def insert_deduplication_info(self, batch: List[str]) -> None:
+    def insert_deduplication_info(self, batch: list[str]) -> None:
         """
         Insert deduplication info in batch
         """
@@ -1487,8 +1487,8 @@ class ClickhouseCTL:
         )
 
     def get_deduplication_info(
-        self, database: str, table: str, frozen_parts: Dict[str, FrozenPart]
-    ) -> List[Dict]:
+        self, database: str, table: str, frozen_parts: dict[str, FrozenPart]
+    ) -> list[dict]:
         """
         Get deduplication info for given frozen parts of a table
         """

--- a/ch_backup/clickhouse/disks.py
+++ b/ch_backup/clickhouse/disks.py
@@ -7,7 +7,7 @@ import os
 from functools import partial
 from subprocess import PIPE, Popen
 from types import TracebackType
-from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Type
+from typing import Any, Callable, Literal, Sequence, Type
 from urllib.parse import urlparse
 
 import xmltodict
@@ -49,9 +49,9 @@ class ClickHouseTemporaryDisks:
         backup_layout: BackupLayout,
         config: Config,
         backup_meta: BackupMetadata,
-        source_bucket: Optional[str],
-        source_path: Optional[str],
-        source_endpoint: Optional[str],
+        source_bucket: str | None,
+        source_path: str | None,
+        source_endpoint: str | None,
         ch_config: ClickhouseConfig,
         desired_tables: Sequence[TableMetadata] | Literal["all"] = "all",
         use_local_copy: bool = False,
@@ -72,9 +72,9 @@ class ClickHouseTemporaryDisks:
             )
         self._desired_tables: Sequence[TableMetadata] | Literal["all"] = desired_tables
 
-        self._disks: Dict[str, Dict] = {}
-        self._created_disks: Dict[str, Disk] = {}
-        self._ch_availible_disks: Dict[str, Disk] = {}
+        self._disks: dict[str, dict] = {}
+        self._created_disks: dict[str, Disk] = {}
+        self._ch_availible_disks: dict[str, Disk] = {}
 
     def __enter__(self):
         self._disks = self._ch_config.config.get("storage_configuration", {}).get(
@@ -103,9 +103,9 @@ class ClickHouseTemporaryDisks:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        value: Optional[BaseException],
-        traceback: Optional[TracebackType],
+        exc_type: Type[BaseException] | None,
+        value: BaseException | None,
+        traceback: TracebackType | None,
     ) -> bool:
         if exc_type is not None:
             logging.warning(
@@ -215,7 +215,7 @@ class ClickHouseTemporaryDisks:
     def copy_parts(
         self,
         backup_meta: BackupMetadata,
-        parts_to_copy: List[Tuple[Table, PartMetadata]],
+        parts_to_copy: list[tuple[Table, PartMetadata]],
         max_proccesses_count: int,
         keep_going: bool,
         part_callback: Callable,
@@ -379,9 +379,9 @@ def _get_tmp_disk_name(disk_name: str) -> str:
 def _exec(
     routine_tag: str,
     exe: str,
-    common_args: List[str],
-    command: Optional[str] = None,
-    command_args: Optional[List[str]] = None,
+    common_args: list[str],
+    command: str | None = None,
+    command_args: list[str] | None = None,
 ) -> Any:
 
     proc_logger = logging.getLogger("clickhouse-disks").bind(tag=routine_tag)

--- a/ch_backup/clickhouse/disks.py
+++ b/ch_backup/clickhouse/disks.py
@@ -7,7 +7,7 @@ import os
 from functools import partial
 from subprocess import PIPE, Popen
 from types import TracebackType
-from typing import Any, Callable, Literal, Sequence, Type
+from typing import Any, Callable, Literal, Sequence
 from urllib.parse import urlparse
 
 import xmltodict
@@ -104,7 +104,7 @@ class ClickHouseTemporaryDisks:
 
     def __exit__(
         self,
-        exc_type: Type[BaseException] | None,
+        exc_type: type[BaseException] | None,
         value: BaseException | None,
         traceback: TracebackType | None,
     ) -> bool:

--- a/ch_backup/clickhouse/metadata_cleaner.py
+++ b/ch_backup/clickhouse/metadata_cleaner.py
@@ -6,7 +6,6 @@ import copy
 import os
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Dict, List, Optional
 
 from kazoo.exceptions import KazooException, NoNodeError
 
@@ -58,7 +57,7 @@ def _is_not_table_path_error(error: ClickhouseError) -> bool:
     return "does not look like a table path" in str(error)
 
 
-def select_replica_drop(replica_name: Optional[str], macros: Dict) -> str:
+def select_replica_drop(replica_name: str | None, macros: dict) -> str:
     """
     Select replica to drop from zookeeper.
     """
@@ -82,7 +81,7 @@ class MetadataCleaner:
         self,
         ch_ctl: ClickhouseCTL,
         zk_ctl: ZookeeperCTL,
-        replica_to_drop: Optional[str],
+        replica_to_drop: str | None,
         max_workers: int,
     ) -> None:
         self._ch_ctl = ch_ctl
@@ -91,13 +90,13 @@ class MetadataCleaner:
         self._replica_to_drop = replica_to_drop
         self._exec_pool = ThreadPoolExecutor(max_workers)
 
-    def clean_tables_metadata(self, replicated_tables: List[Table]) -> None:
+    def clean_tables_metadata(self, replicated_tables: list[Table]) -> None:
         """
         Remove replica tables metadata from zookeeper.
         """
         replicated_table_paths = get_table_zookeeper_paths(replicated_tables)
         # Key is "{table_name}/{replica}" to correctly handle multiple replicas per table.
-        cleanup_tasks: Dict[str, _TableCleanupTask] = {}
+        cleanup_tasks: dict[str, _TableCleanupTask] = {}
         for table, table_path in replicated_table_paths:
             self._schedule_table_replicas_cleanup(table, table_path, cleanup_tasks)
 
@@ -141,7 +140,7 @@ class MetadataCleaner:
         self,
         table: Table,
         table_path: str,
-        cleanup_tasks: Dict[str, _TableCleanupTask],
+        cleanup_tasks: dict[str, _TableCleanupTask],
     ) -> None:
         """
         Schedule ZK metadata cleanup tasks for all replicas of a single table.
@@ -219,7 +218,7 @@ class MetadataCleaner:
                 # Node already deleted, it's fine
                 logging.debug("ZK node {} was already deleted", zk_path)
 
-    def _list_replicas(self, zk_path: str) -> List[str]:
+    def _list_replicas(self, zk_path: str) -> list[str]:
         replicas_path = (
             self._zk_ctl.zk_root_path + zk_path + "/replicas/"  # type: ignore
         )
@@ -229,7 +228,7 @@ class MetadataCleaner:
             except NoNodeError:
                 return []
 
-    def clean_database_metadata(self, replicated_databases: List[Database]) -> None:
+    def clean_database_metadata(self, replicated_databases: list[Database]) -> None:
         """
         Remove replica database metadata from zookeeper.
         """
@@ -240,7 +239,7 @@ class MetadataCleaner:
             return
 
         replicated_databases_paths = get_database_zookeeper_paths(replicated_databases)
-        tasks: Dict[str, Future] = {}
+        tasks: dict[str, Future] = {}
 
         for database, database_path, shard in replicated_databases_paths:
             db_macros = copy.copy(self._macros)

--- a/ch_backup/clickhouse/models.py
+++ b/ch_backup/clickhouse/models.py
@@ -7,9 +7,6 @@ import re
 from enum import Enum
 from types import SimpleNamespace
 
-# from typing import Any, List, Optional, Tuple
-from typing import List, Optional, Tuple
-
 import ch_backup.logging
 from ch_backup.util import Slotted
 
@@ -34,9 +31,9 @@ class Disk(SimpleNamespace):
         name: str,
         path: str,
         disk_type: str,
-        object_storage_type: Optional[str] = None,
-        metadata_storage_type: Optional[str] = None,
-        cache_path: Optional[str] = None,
+        object_storage_type: str | None = None,
+        metadata_storage_type: str | None = None,
+        cache_path: str | None = None,
     ):
         super().__init__()
         self.name = name
@@ -75,11 +72,11 @@ class Table(SimpleNamespace):
         database: str,
         name: str,
         engine: str,
-        disks: List[Disk],
-        data_paths: List[str],
+        disks: list[Disk],
+        data_paths: list[str],
         metadata_path: str,
         create_statement: str,
-        uuid: Optional[str],
+        uuid: str | None,
     ) -> None:
         super().__init__()
         self.database = database
@@ -96,7 +93,7 @@ class Table(SimpleNamespace):
             self.path_on_disk = os.path.relpath(path, disk.path)
 
     @property
-    def uuid(self) -> Optional[str]:
+    def uuid(self) -> str | None:
         """
         Return table UUID or None if it's a zero UUID (for Ordinary databases).
         """
@@ -105,7 +102,7 @@ class Table(SimpleNamespace):
         return self._uuid
 
     @uuid.setter
-    def uuid(self, value: Optional[str]) -> None:
+    def uuid(self, value: str | None) -> None:
         """
         Set table UUID.
         """
@@ -121,8 +118,8 @@ class Table(SimpleNamespace):
         return cls(database, name, "", [], [], metadata_path, "", uuid)
 
     def _map_paths_to_disks(
-        self, disks: List[Disk], data_paths: List[str]
-    ) -> List[Tuple[str, Disk]]:
+        self, disks: list[Disk], data_paths: list[str]
+    ) -> list[tuple[str, Disk]]:
         return list(
             map(
                 lambda data_path: (data_path, self._map_path_to_disk(disks, data_path)),
@@ -211,7 +208,7 @@ class Table(SimpleNamespace):
         return self.engine == "Dictionary"
 
     @staticmethod
-    def _map_path_to_disk(disks: List[Disk], data_path: str) -> Disk:
+    def _map_path_to_disk(disks: list[Disk], data_path: str) -> Disk:
         matched_disks = list(
             filter(lambda disk: data_path.startswith(disk.path), disks)
         )
@@ -230,10 +227,10 @@ class Database(SimpleNamespace):
     def __init__(
         self,
         name: str,
-        engine: Optional[str],
-        metadata_path: Optional[str],
-        uuid: Optional[str],
-        engine_full: Optional[str],
+        engine: str | None,
+        metadata_path: str | None,
+        uuid: str | None,
+        engine_full: str | None,
     ) -> None:
         super().__init__()
         self.name = name
@@ -316,7 +313,7 @@ class FrozenPart(Slotted):
         path: str,
         checksum: str,
         size: int,
-        files: List[str],
+        files: list[str],
     ):
         super().__init__()
         self.database = database

--- a/ch_backup/compression/__init__.py
+++ b/ch_backup/compression/__init__.py
@@ -8,7 +8,7 @@ from ch_backup.compression.base import BaseCompression
 from ch_backup.compression.gzip import GZIPCompression
 from ch_backup.exceptions import UnknownEncryptionError
 
-SUPPORTED_COMPRESSION: Mapping[str, Type[BaseCompression]] = {
+SUPPORTED_COMPRESSION: Mapping[str, type[BaseCompression]] = {
     "gzip": GZIPCompression,
 }
 

--- a/ch_backup/encryption/__init__.py
+++ b/ch_backup/encryption/__init__.py
@@ -9,7 +9,7 @@ from ch_backup.encryption.nacl import NaClEncryption
 from ch_backup.encryption.noop import NoopEncryption
 from ch_backup.exceptions import UnknownEncryptionError
 
-SUPPORTED_CRYPTO: Mapping[str, Type[BaseEncryption]] = {
+SUPPORTED_CRYPTO: Mapping[str, type[BaseEncryption]] = {
     "noop": NoopEncryption,
     "nacl": NaClEncryption,
 }

--- a/ch_backup/logic/access.py
+++ b/ch_backup/logic/access.py
@@ -5,7 +5,7 @@ Clickhouse backup logic for access entities.
 import os
 import re
 import shutil
-from typing import Any, Dict, List, Sequence, Union
+from typing import Any, Sequence
 
 from kazoo.client import KazooClient
 from kazoo.exceptions import NoNodeError
@@ -176,7 +176,7 @@ class AccessBackup(BackupManager):
                     logging.debug(f"File {file_path} not found.")
 
     def _download_access_control_list(
-        self, context: BackupContext, restore_tmp_path: str, acl_ids: List[str]
+        self, context: BackupContext, restore_tmp_path: str, acl_ids: list[str]
     ) -> None:
         if context.backup_meta.access_control.backup_format == BackupStorageFormat.TAR:
             context.backup_layout.download_access_control(
@@ -233,7 +233,7 @@ class AccessBackup(BackupManager):
         self,
         restore_tmp_path: str,
         acl_list: Sequence[str],
-        acl_meta: Dict[str, Dict[str, Any]],
+        acl_meta: dict[str, dict[str, Any]],
         context: BackupContext,
     ) -> None:
         """
@@ -296,7 +296,7 @@ class AccessBackup(BackupManager):
         )
 
 
-def _get_access_control_files(objects: Sequence[str]) -> List[str]:
+def _get_access_control_files(objects: Sequence[str]) -> list[str]:
     """
     Return list of file to be backuped/restored.
     """
@@ -313,7 +313,7 @@ def _get_access_zk_path(context: BackupContext, zk_path: str) -> str:
     return "/" + os.path.join(*map(lambda x: x.lstrip("/"), paths))
 
 
-def _zk_upsert_data(zk: KazooClient, path: str, value: Union[str, bytes]) -> None:
+def _zk_upsert_data(zk: KazooClient, path: str, value: str | bytes) -> None:
     if isinstance(value, str):
         value = value.encode()
 

--- a/ch_backup/logic/database.py
+++ b/ch_backup/logic/database.py
@@ -4,7 +4,7 @@ ClickHouse backup logic for databases.
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Sequence
+from typing import Sequence
 
 from ch_backup import logging
 from ch_backup.backup_context import BackupContext
@@ -59,10 +59,10 @@ class DatabaseBackup(BackupManager):
     @staticmethod
     def restore(
         context: BackupContext,
-        databases: Dict[str, Database],
+        databases: dict[str, Database],
         keep_going: bool,
-        metadata_cleaner: Optional[MetadataCleaner],
-    ) -> List[Database]:
+        metadata_cleaner: MetadataCleaner | None,
+    ) -> list[Database]:
         """
         Restore database objects.
         """
@@ -70,7 +70,7 @@ class DatabaseBackup(BackupManager):
         logging.debug("Retrieving list of databases")
         present_databases = {db.name: db for db in context.ch_ctl.get_databases()}
 
-        databases_to_restore: Dict[str, Database] = {}
+        databases_to_restore: dict[str, Database] = {}
         for name, db in databases.items():
             if (
                 name in present_databases

--- a/ch_backup/logic/database_sync.py
+++ b/ch_backup/logic/database_sync.py
@@ -9,7 +9,7 @@ import re
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, Iterable
+from typing import Iterable
 
 from ch_backup import logging
 from ch_backup.backup_context import BackupContext
@@ -73,7 +73,7 @@ class DatabaseZookeeperData:
         return self._read_int_node(self._full_path("/max_log_ptr"))
 
     @staticmethod
-    def parse_replicated_db_zk_info(db: Database, macros: Dict[str, str]) -> tuple:
+    def parse_replicated_db_zk_info(db: Database, macros: dict[str, str]) -> tuple:
         """
         Parse ZooKeeper path, shard, and replica from Replicated database engine_full.
         """
@@ -209,7 +209,7 @@ def wait_sync_replicated_databases(
     context: BackupContext,
     databases: Iterable[Database],
     keep_going: bool,
-) -> Dict[str, SyncStatus]:
+) -> dict[str, SyncStatus]:
     """
     Wait for replicated databases to sync by polling ZooKeeper log pointers.
 
@@ -236,7 +236,7 @@ def wait_sync_replicated_databases(
 
     cfg = context.ch_ctl_conf
     deadline = time.time() + cfg["sync_database_replica_timeout"]
-    results: Dict[str, SyncStatus] = {}
+    results: dict[str, SyncStatus] = {}
 
     for db in databases:
         if not db.is_replicated_db_engine():

--- a/ch_backup/logic/lock_manager.py
+++ b/ch_backup/logic/lock_manager.py
@@ -7,7 +7,7 @@ import socket
 import sys
 from fcntl import LOCK_SH, flock
 from types import TracebackType
-from typing import IO, Any, Type
+from typing import IO, Any
 
 from kazoo.exceptions import LockTimeout
 from kazoo.recipe.lock import Lock
@@ -80,7 +80,7 @@ class LockManager:
 
     def __exit__(
         self,
-        exc_type: Type[BaseException] | None,
+        exc_type: type[BaseException] | None,
         exc_inst: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:

--- a/ch_backup/logic/lock_manager.py
+++ b/ch_backup/logic/lock_manager.py
@@ -7,7 +7,7 @@ import socket
 import sys
 from fcntl import LOCK_SH, flock
 from types import TracebackType
-from typing import IO, Any, Optional, Type
+from typing import IO, Any, Type
 
 from kazoo.exceptions import LockTimeout
 from kazoo.recipe.lock import Lock
@@ -31,17 +31,15 @@ class LockManager:
     _lock_id: str
     _logger: Any
 
-    def __init__(self, lock_conf: dict, zk_ctl: Optional[ZookeeperCTL]) -> None:
+    def __init__(self, lock_conf: dict, zk_ctl: ZookeeperCTL | None) -> None:
         """
         Init-method for lock manager
         """
         self._lock_conf = lock_conf
         self._process_lockfile_path = str(lock_conf.get("flock_path"))
         self._process_zk_lockfile_path = str(lock_conf.get("zk_flock_path"))
-        self._zk_client: Optional[ZookeeperClient] = (
-            zk_ctl.zk_client if zk_ctl else None
-        )
-        self._zk_lock: Optional[Lock] = None
+        self._zk_client: ZookeeperClient | None = zk_ctl.zk_client if zk_ctl else None
+        self._zk_lock: Lock | None = None
         self._exitcode = lock_conf.get("exitcode")
         self._distributed = zk_ctl is None
         self._disabled = False
@@ -82,9 +80,9 @@ class LockManager:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_inst: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
+        exc_type: Type[BaseException] | None,
+        exc_inst: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         """
         Exit-method for context manager

--- a/ch_backup/logic/named_collections.py
+++ b/ch_backup/logic/named_collections.py
@@ -6,7 +6,6 @@ import os
 import posixpath
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List
 
 from ch_backup import logging
 from ch_backup.backup_context import BackupContext
@@ -134,7 +133,7 @@ class NamedCollectionsBackup(BackupManager):
         logging.info("All named collections restored")
 
     @staticmethod
-    def get_named_collections_list(context: BackupContext) -> List[str]:
+    def get_named_collections_list(context: BackupContext) -> list[str]:
         """
         Get named collections list
         """

--- a/ch_backup/logic/partial_restore.py
+++ b/ch_backup/logic/partial_restore.py
@@ -3,7 +3,6 @@ Clickhouse partial restore helper
 """
 
 import fnmatch
-from typing import List
 
 
 class PartialRestorePattern:
@@ -44,7 +43,7 @@ class PartialRestoreFilter:
     Contains filtering logic for partial restore command
     """
 
-    def __init__(self, inverted: bool, patterns: List[str]):
+    def __init__(self, inverted: bool, patterns: list[str]):
         """
         @param inverted: include(false) or exclude(true) matcher
         @param patterns: table patterns in format db_name.table_name with possible * in table_name

--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -12,7 +12,7 @@ from itertools import chain
 from pathlib import Path
 from random import choices
 from string import ascii_lowercase
-from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from typing import Dict, Iterable, Optional, Sequence
 
 from ch_backup import logging
 from ch_backup.backup.deduplication import deduplicate_parts
@@ -60,9 +60,9 @@ class TableBackup(BackupManager):
         self,
         context: BackupContext,
         databases: Sequence[Database],
-        db_tables: Dict[str, list],
+        db_tables: dict[str, list],
         schema_only: bool,
-        multiprocessing_config: Dict,
+        multiprocessing_config: dict,
     ) -> None:
         """
         Backup tables metadata, MergeTree data and Cloud storage metadata.
@@ -108,13 +108,13 @@ class TableBackup(BackupManager):
         self,
         context: BackupContext,
         databases: Sequence[Database],
-        db_tables: Dict[str, list],
+        db_tables: dict[str, list],
     ) -> Dict[Table, TableMetadataChangeTime]:
         """
         Collect modification timestamps of table metadata files.
         """
         logging.debug("Collecting local metadata modification times")
-        res: Dict[Table, TableMetadataChangeTime] = {}
+        res: dict[Table, TableMetadataChangeTime] = {}
 
         for db in databases:
             if db.is_external_db_engine():
@@ -324,11 +324,11 @@ class TableBackup(BackupManager):
         context: BackupContext,
         databases: Dict[str, Database],
         schema_only: bool,
-        tables: List[TableMetadata],
-        metadata_cleaner: Optional[MetadataCleaner],
-        cloud_storage_source_bucket: Optional[str],
-        cloud_storage_source_path: Optional[str],
-        cloud_storage_source_endpoint: Optional[str],
+        tables: list[TableMetadata],
+        metadata_cleaner: MetadataCleaner | None,
+        cloud_storage_source_bucket: str | None,
+        cloud_storage_source_path: str | None,
+        cloud_storage_source_endpoint: str | None,
         skip_cloud_storage: bool,
         keep_going: bool,
         restore_tables_in_replicated_database: bool,
@@ -337,7 +337,7 @@ class TableBackup(BackupManager):
         Restore tables and MergeTree data.
         """
         logging.debug("Retrieving tables metadata")
-        tables_meta: List[TableMetadata] = list(
+        tables_meta: list[TableMetadata] = list(
             chain(
                 *[
                     context.backup_meta.get_tables(db.name)
@@ -624,11 +624,11 @@ class TableBackup(BackupManager):
     def _preprocess_tables_to_restore(
         self,
         context: BackupContext,
-        databases: Dict[str, Database],
-        tables: List[Table],
+        databases: dict[str, Database],
+        tables: list[Table],
         keep_going: bool,
         restore_tables_in_replicated_database: bool,
-        metadata_cleaner: Optional[MetadataCleaner],
+        metadata_cleaner: MetadataCleaner | None,
     ) -> tuple[list[Table], int]:
         # Prepare table schema to restore.
 
@@ -653,8 +653,8 @@ class TableBackup(BackupManager):
             )
         )
 
-        result: List[Table] = []
-        tables_to_clean_metadata: List[Table] = []
+        result: list[Table] = []
+        tables_to_clean_metadata: list[Table] = []
         preprocessing_failed_skipped = 0
         for table in tables:
             table_name_for_logs = f'"{table.database}"."{table.name}"'
@@ -769,9 +769,9 @@ class TableBackup(BackupManager):
     def _get_remaining_readonly_tables_after_fix_attempt(
         self,
         context: BackupContext,
-        tables: List[Table],
-        metadata_cleaner: Optional[MetadataCleaner],
-    ) -> Tuple[Set[Tuple[str, str]], Set[Tuple[str, str]]]:
+        tables: list[Table],
+        metadata_cleaner: MetadataCleaner | None,
+    ) -> tuple[set[tuple[str, str]], set[tuple[str, str]]]:
         """
         Find replicated tables that are in readonly state and attempt to fix them in-place by:
         1. Cleaning ZooKeeper metadata via MetadataCleaner
@@ -823,7 +823,7 @@ class TableBackup(BackupManager):
             for replica in context.ch_ctl.get_replicas(readonly=True)
         }
 
-        already_cleaned: Set[Tuple[str, str]] = {
+        already_cleaned: set[tuple[str, str]] = {
             (table.database, table.name) for table in replicated_readonly_tables
         }
         for table in replicated_readonly_tables:
@@ -1000,7 +1000,7 @@ class TableBackup(BackupManager):
         databases: Dict[str, Database],
         tables: Iterable[Table],
         keep_going: bool = False,
-    ) -> List[Table]:
+    ) -> list[Table]:
         logging.info("Preparing tables for restoring")
 
         merge_tree_tables = []
@@ -1208,12 +1208,12 @@ class TableBackup(BackupManager):
     def _restore_table_objects(
         self,
         context: BackupContext,
-        databases: Dict[str, Database],
+        databases: dict[str, Database],
         tables: Iterable[Table],
         keep_going: bool = False,
-    ) -> List[Table]:
+    ) -> list[Table]:
         logging.info("Restoring tables")
-        errors: List[Tuple[Table, Exception]] = []
+        errors: list[tuple[Table, Exception]] = []
         unprocessed = deque(table for table in tables)
         while unprocessed:
             table = unprocessed.popleft()
@@ -1271,7 +1271,7 @@ class TableBackup(BackupManager):
     def _check_readonly_restored_tables(
         context: BackupContext,
         tables: Iterable[Table],
-        errors: List[Tuple[Table, Exception]],
+        errors: list[tuple[Table, Exception]],
     ) -> None:
         """
         Successful RESTORE REPLICA doesn't mean that replica becomes active.

--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -461,7 +461,6 @@ class TableBackup(BackupManager):
         context: BackupContext,
         table: Table,
         backup_name: str,
-        change_times: dict[Table, TableMetadataChangeTime],
         expected_change_time: TableMetadataChangeTime,
         *,
         check_table_exists: bool = False,

--- a/ch_backup/logic/table.py
+++ b/ch_backup/logic/table.py
@@ -12,7 +12,7 @@ from itertools import chain
 from pathlib import Path
 from random import choices
 from string import ascii_lowercase
-from typing import Dict, Iterable, Optional, Sequence
+from typing import Iterable, Sequence
 
 from ch_backup import logging
 from ch_backup.backup.deduplication import deduplicate_parts
@@ -109,7 +109,7 @@ class TableBackup(BackupManager):
         context: BackupContext,
         databases: Sequence[Database],
         db_tables: dict[str, list],
-    ) -> Dict[Table, TableMetadataChangeTime]:
+    ) -> dict[Table, TableMetadataChangeTime]:
         """
         Collect modification timestamps of table metadata files.
         """
@@ -141,8 +141,8 @@ class TableBackup(BackupManager):
         tables: Sequence[str],
         backup_name: str,
         schema_only: bool,
-        multiprocessing_config: Dict,
-        change_times: Dict[Table, TableMetadataChangeTime],
+        multiprocessing_config: dict,
+        change_times: dict[Table, TableMetadataChangeTime],
     ) -> None:
         """
         Backup single database tables.
@@ -231,7 +231,7 @@ class TableBackup(BackupManager):
         parallelize_freeze_in_ch: bool,
         freeze_partition_threads: int,
         freeze_table_query_max_threads: int,
-    ) -> Optional[Table]:
+    ) -> Table | None:
         """
         Freeze table and return it's create statement
         """
@@ -275,7 +275,7 @@ class TableBackup(BackupManager):
         return table
 
     @staticmethod
-    def _load_create_statement_from_disk(table: Table) -> Optional[str]:
+    def _load_create_statement_from_disk(table: Table) -> str | None:
         """
         Load a create statement of the table from a metadata file on the disk.
         """
@@ -322,7 +322,7 @@ class TableBackup(BackupManager):
     def restore(
         self,
         context: BackupContext,
-        databases: Dict[str, Database],
+        databases: dict[str, Database],
         schema_only: bool,
         tables: list[TableMetadata],
         metadata_cleaner: MetadataCleaner | None,
@@ -458,7 +458,7 @@ class TableBackup(BackupManager):
         context: BackupContext,
         table: Table,
         backup_name: str,
-        change_times: Dict[Table, TableMetadataChangeTime],
+        change_times: dict[Table, TableMetadataChangeTime],
     ) -> bool:
         """
         Check if table metadata was updated.
@@ -488,7 +488,7 @@ class TableBackup(BackupManager):
         def deduplicate_parts_in_batch(
             context: BackupContext,
             upload_observer: UploadPartObserver,
-            frozen_parts: Dict[str, FrozenPart],
+            frozen_parts: dict[str, FrozenPart],
         ) -> None:
             logging.debug(
                 "Working on deduplication of {} frozen parts", len(frozen_parts)
@@ -535,7 +535,7 @@ class TableBackup(BackupManager):
 
         upload_observer = UploadPartObserver(context)
 
-        frozen_parts_batch: Dict[str, FrozenPart] = {}
+        frozen_parts_batch: dict[str, FrozenPart] = {}
         dedup_batch_size = context.config["deduplication_batch_size"]
         for data_path, disk in table.paths_with_disks:
             for fpart in context.ch_ctl.scan_frozen_parts(
@@ -595,7 +595,7 @@ class TableBackup(BackupManager):
                 )
 
     @staticmethod
-    def _get_change_time(file_name: str) -> Optional[TableMetadataChangeTime]:
+    def _get_change_time(file_name: str) -> TableMetadataChangeTime | None:
         """
         Fetch change time of the table metadata file safely.
         """
@@ -689,7 +689,7 @@ class TableBackup(BackupManager):
                         else:
                             raise
 
-                existing_table: Optional[Table] = None
+                existing_table: Table | None = None
                 if (table.database, table.name) in existing_readonly_tables:
                     existing_table = table
                     logging.warning(
@@ -997,7 +997,7 @@ class TableBackup(BackupManager):
     def _restore_tables(
         self,
         context: BackupContext,
-        databases: Dict[str, Database],
+        databases: dict[str, Database],
         tables: Iterable[Table],
         keep_going: bool = False,
     ) -> list[Table]:

--- a/ch_backup/logic/udf.py
+++ b/ch_backup/logic/udf.py
@@ -2,8 +2,6 @@
 Clickhouse backup logic for UDFs
 """
 
-from typing import List
-
 from ch_backup import logging
 from ch_backup.backup_context import BackupContext
 from ch_backup.logic.backup_manager import BackupManager
@@ -72,7 +70,7 @@ class UDFBackup(BackupManager):
         return statement.replace("CREATE FUNCTION", "CREATE OR REPLACE FUNCTION", 1)
 
     @staticmethod
-    def get_udf_list(context: BackupContext) -> List[str]:
+    def get_udf_list(context: BackupContext) -> list[str]:
         """
         Get UDF list
         """

--- a/ch_backup/logic/upload_part_observer.py
+++ b/ch_backup/logic/upload_part_observer.py
@@ -1,7 +1,6 @@
 """Uploading part observer."""
 
 import time
-from typing import List
 
 from ch_backup.backup.metadata import PartMetadata
 from ch_backup.backup_context import BackupContext
@@ -18,7 +17,7 @@ class UploadPartObserver:
     def __init__(self, context: BackupContext) -> None:
         self._context = context
         self._last_time = time.time()
-        self._uploaded_parts: List[PartMetadata] = []
+        self._uploaded_parts: list[PartMetadata] = []
         self._interval = self._context.config["update_metadata_interval"]
 
     def __call__(self, part: PartMetadata) -> None:
@@ -33,7 +32,7 @@ class UploadPartObserver:
             self._last_time = now
 
     @property
-    def uploaded_parts(self) -> List[PartMetadata]:
+    def uploaded_parts(self) -> list[PartMetadata]:
         """
         Return uploaded parts metadata.
         """

--- a/ch_backup/logic/workload_entities.py
+++ b/ch_backup/logic/workload_entities.py
@@ -7,7 +7,6 @@ import posixpath
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional
 
 from ch_backup import logging
 from ch_backup.backup_context import BackupContext
@@ -33,7 +32,7 @@ class WorkloadEntity:
     name: str
     type: WorkloadEntityType
     create_statement: str
-    parent: Optional[str] = None
+    parent: str | None = None
 
     def filename_on_disk(self) -> str:
         """

--- a/ch_backup/logic/workload_entities.py
+++ b/ch_backup/logic/workload_entities.py
@@ -7,7 +7,7 @@ import posixpath
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Optional, Tuple
+from typing import Optional
 
 from ch_backup import logging
 from ch_backup.backup_context import BackupContext
@@ -105,7 +105,7 @@ class WorkloadEntitiesBackup(BackupManager):
             )
             return
 
-        workload_entities: List[Tuple[str, WorkloadEntityType]] = (
+        workload_entities: list[tuple[str, WorkloadEntityType]] = (
             context.ch_ctl.get_workload_entities_query()
         )
 
@@ -173,8 +173,8 @@ class WorkloadEntitiesBackup(BackupManager):
 
         we_on_clickhouse = dict(context.ch_ctl.get_workload_entities_query())
 
-        resources_from_backup: List[WorkloadEntity] = []
-        workloads_from_backup: List[WorkloadEntity] = []
+        resources_from_backup: list[WorkloadEntity] = []
+        workloads_from_backup: list[WorkloadEntity] = []
 
         for entity_name in we_list:
             statement = context.backup_layout.get_workload_entity_create_statement(
@@ -242,8 +242,8 @@ class WorkloadEntitiesBackup(BackupManager):
 
     @staticmethod
     def topologically_sort_workload_entities(
-        workload_entities: List[WorkloadEntity],
-    ) -> List[WorkloadEntity]:
+        workload_entities: list[WorkloadEntity],
+    ) -> list[WorkloadEntity]:
         """
         Sort WORKLOAD entities create them in the right order.
         """
@@ -306,7 +306,7 @@ class WorkloadEntitiesBackup(BackupManager):
             # CREATE RESOURCE s3_read (READ DISK s3);
             # CREATE WORKLOAD `all` SETTINGS max_bytes_per_second = 2147483648;
             we_create_statements_binary, _ = client.get(from_path)
-            we_create_statements: List[str] = we_create_statements_binary.decode(
+            we_create_statements: list[str] = we_create_statements_binary.decode(
                 "utf-8"
             ).splitlines()
 

--- a/ch_backup/params.py
+++ b/ch_backup/params.py
@@ -4,7 +4,6 @@ ParamType declarations.
 
 import json
 import re
-import typing
 from collections import defaultdict
 
 from click import ParamType
@@ -48,7 +47,7 @@ class List(ParamType):
             self.fail(msg, param, ctx)
 
 
-KeyValue = typing.Dict[str, str]
+KeyValue = dict[str, str]
 
 
 class KeyValueList(List):
@@ -81,7 +80,7 @@ class KeyValueList(List):
             self.fail(f'"{value}" is not a valid list of key-value', param, ctx)
 
 
-KeyValues = typing.Dict[str, typing.List[str]]
+KeyValues = dict[str, list[str]]
 
 
 class KeyValuesList(KeyValueList):

--- a/ch_backup/storage/async_pipeline/base_pipeline/exec_pool.py
+++ b/ch_backup/storage/async_pipeline/base_pipeline/exec_pool.py
@@ -15,7 +15,7 @@ from concurrent.futures import (
 )
 from dataclasses import dataclass
 from multiprocessing import get_context
-from typing import Any, Callable, Dict, Iterable, Optional
+from typing import Any, Callable, Iterable
 
 from ch_backup import logging
 from ch_backup.util import exhaust_iterator
@@ -32,7 +32,7 @@ class Job:
     """
 
     id_: str
-    callback: Optional[Callable]
+    callback: Callable | None
 
 
 class ExecPool:
@@ -43,7 +43,7 @@ class ExecPool:
     """
 
     def __init__(self, executor: Executor) -> None:
-        self._future_to_job: Dict[Future, Job] = {}
+        self._future_to_job: dict[Future, Job] = {}
         self._pool = executor
         # It is necessary to start all processes while there are no running threads
         # Used to freeze and backup tables at the same time
@@ -60,7 +60,7 @@ class ExecPool:
         job_id: str,
         func: Callable,
         *args: Any,
-        callback: Optional[Callable] = None,
+        callback: Callable | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -81,7 +81,7 @@ class ExecPool:
         future.result()
 
     def as_completed(
-        self, keep_going: bool = False, timeout: Optional[float] = None
+        self, keep_going: bool = False, timeout: float | None = None
     ) -> Iterable[Any]:
         """
         Return result from futures as they are completed.
@@ -115,9 +115,7 @@ class ExecPool:
 
         self._future_to_job = {}
 
-    def wait_all(
-        self, keep_going: bool = False, timeout: Optional[float] = None
-    ) -> None:
+    def wait_all(self, keep_going: bool = False, timeout: float | None = None) -> None:
         """
         Wait workers for complete jobs.
 

--- a/ch_backup/storage/async_pipeline/base_pipeline/flat_map.py
+++ b/ch_backup/storage/async_pipeline/base_pipeline/flat_map.py
@@ -4,7 +4,7 @@ Flat map runner for stage.
 
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Iterable, Optional, Union
+from typing import Any, Callable, Iterable
 
 from pypeln import utils as pypeln_utils
 from pypeln.thread import Worker
@@ -46,16 +46,14 @@ class FlatMap:
 # pylint: disable=too-many-positional-arguments
 def flat_map(
     f: IterableHandler,
-    stage: Union[
-        Stage[A], Iterable[A], pypeln_utils.Undefined
-    ] = pypeln_utils.UNDEFINED,
+    stage: Stage[A] | Iterable[A] | pypeln_utils.Undefined = pypeln_utils.UNDEFINED,
     workers: int = 1,
     maxsize: int = 0,
     timeout: float = 0,
     on_start: Callable = None,
     on_done: Callable = None,
     use_threads: bool = True,
-) -> Union[Optional[Stage[None]], pypeln_utils.Partial[Optional[Stage[None]]]]:
+) -> (Stage[None] | None) | pypeln_utils.Partial[Stage[None] | None]:
     """
     Create flat map stage.
 

--- a/ch_backup/storage/async_pipeline/base_pipeline/handler.py
+++ b/ch_backup/storage/async_pipeline/base_pipeline/handler.py
@@ -3,7 +3,7 @@ Abstract base classes for stage handlers.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable
 
 
 class Handler(ABC):
@@ -12,7 +12,7 @@ class Handler(ABC):
     """
 
     @abstractmethod
-    def __call__(self, value: Any, index: int) -> Optional[Any]:
+    def __call__(self, value: Any, index: int) -> Any | None:
         """
         Process value at number index from pipeline and optionally produce result.
 
@@ -20,7 +20,7 @@ class Handler(ABC):
         """
         pass
 
-    def on_start(self) -> Optional[Any]:
+    def on_start(self) -> Any | None:
         """
         Executed on starting pipeline and return optional value to pipeline.
 
@@ -28,7 +28,7 @@ class Handler(ABC):
         """
         pass
 
-    def on_done(self) -> Optional[Any]:
+    def on_done(self) -> Any | None:
         """
         Executed when all previous stages are done and return optional value to pipeline.
 
@@ -43,7 +43,7 @@ class IterableHandler(ABC):
     """
 
     @abstractmethod
-    def __call__(self, value: Any, index: int) -> Optional[Iterable[Any]]:
+    def __call__(self, value: Any, index: int) -> Iterable[Any] | None:
         """
         Process value at number index from pipeline and optionally produce iterable result.
 
@@ -51,7 +51,7 @@ class IterableHandler(ABC):
         """
         pass
 
-    def on_start(self) -> Optional[Iterable[Any]]:
+    def on_start(self) -> Iterable[Any] | None:
         """
         Executed on starting pipeline and return optional iterable value to pipeline.
 
@@ -59,7 +59,7 @@ class IterableHandler(ABC):
         """
         pass
 
-    def on_done(self) -> Optional[Iterable[Any]]:
+    def on_done(self) -> Iterable[Any] | None:
         """
         Executed when all previous stages are done and return optional iterable value to pipeline.
 
@@ -74,7 +74,7 @@ class InputHandler(ABC):
     """
 
     @abstractmethod
-    def __call__(self) -> Optional[Iterable[Any]]:
+    def __call__(self) -> Iterable[Any] | None:
         """
         Executed on starting pipeline (but after on_start) and return optional iterable value to pipeline.
 
@@ -82,7 +82,7 @@ class InputHandler(ABC):
         """
         pass
 
-    def on_start(self) -> Optional[Any]:
+    def on_start(self) -> Any | None:
         """
         Executed on starting pipeline and return optional iterable value to pipeline.
 
@@ -90,7 +90,7 @@ class InputHandler(ABC):
         """
         pass
 
-    def on_done(self) -> Optional[Any]:
+    def on_done(self) -> Any | None:
         """
         Executed when all previous stages are done and return optional iterable value to pipeline.
 

--- a/ch_backup/storage/async_pipeline/base_pipeline/input.py
+++ b/ch_backup/storage/async_pipeline/base_pipeline/input.py
@@ -4,7 +4,7 @@ Input runner for stage.
 
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Iterable, Optional, Union
+from typing import Any, Callable, Iterable
 
 from pypeln import utils as pypeln_utils
 from pypeln.thread import Worker
@@ -48,16 +48,14 @@ class Input:
 # pylint: disable=too-many-positional-arguments
 def input_(
     f: InputHandler,
-    stage: Union[
-        Stage[A], Iterable[A], pypeln_utils.Undefined
-    ] = pypeln_utils.UNDEFINED,
+    stage: Stage[A] | Iterable[A] | pypeln_utils.Undefined = pypeln_utils.UNDEFINED,
     workers: int = 1,
     maxsize: int = 0,
     timeout: float = 0,
     on_start: Callable = None,
     on_done: Callable = None,
     use_threads: bool = True,
-) -> Union[Optional[Stage[None]], pypeln_utils.Partial[Optional[Stage[None]]]]:
+) -> Stage[None] | pypeln_utils.Partial[Stage[None] | None] | None:
     """
     Create an input stage that doesn't have an input data but has outputs.
 

--- a/ch_backup/storage/async_pipeline/base_pipeline/map.py
+++ b/ch_backup/storage/async_pipeline/base_pipeline/map.py
@@ -4,7 +4,7 @@ Map runner for stage.
 
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Iterable, Optional, Union
+from typing import Any, Callable, Iterable
 
 from pypeln import utils as pypeln_utils
 from pypeln.thread import Worker
@@ -36,7 +36,7 @@ class Map:
                 )
                 idx += 1
 
-    def process(self, worker: Worker) -> Iterable[Optional[B]]:
+    def process(self, worker: Worker) -> Iterable[B | None]:
         """
         Process map handler.
         """
@@ -51,16 +51,14 @@ class Map:
 # pylint: disable=too-many-positional-arguments
 def map_(
     f: Handler,
-    stage: Union[
-        Stage[A], Iterable[A], pypeln_utils.Undefined
-    ] = pypeln_utils.UNDEFINED,
+    stage: Stage[A] | Iterable[A] | pypeln_utils.Undefined = pypeln_utils.UNDEFINED,
     workers: int = 1,
     maxsize: int = 0,
     timeout: float = 0,
     on_start: Callable = None,
     on_done: Callable = None,
     use_threads: bool = True,
-) -> Union[Optional[Stage[None]], pypeln_utils.Partial[Optional[Stage[None]]]]:
+) -> Stage[None] | pypeln_utils.Partial[Stage[None] | None] | None:
     """
     Create map stage.
     """

--- a/ch_backup/storage/async_pipeline/pipeline_builder.py
+++ b/ch_backup/storage/async_pipeline/pipeline_builder.py
@@ -5,7 +5,7 @@ Pipeline builder.
 from functools import reduce
 from math import ceil
 from pathlib import Path
-from typing import Any, BinaryIO, Iterable, List, Optional, Sequence, Union
+from typing import Any, BinaryIO, Iterable, Sequence, Union
 
 from pypeln import utils as pypeln_utils
 from pypeln.thread.api.from_iterable import from_iterable
@@ -41,7 +41,7 @@ from ch_backup.storage.async_pipeline.stages import (
 from ch_backup.storage.engine import get_storage_engine
 
 # Union here is a workaround according to https://github.com/python/mypy/issues/7866
-PypelnStage = Union[pypeln_utils.BaseStage]
+PypelnStage = Union[pypeln_utils.BaseStage]  # noqa: UP007
 
 
 class PipelineBuilder:
@@ -53,7 +53,7 @@ class PipelineBuilder:
 
     def __init__(self, config: dict) -> None:
         self._config = config
-        self._stages: List[PypelnStage] = []
+        self._stages: list[PypelnStage] = []
 
     def build_iterable_stage(self, iterable: Iterable[Any]) -> "PipelineBuilder":
         """
@@ -116,8 +116,8 @@ class PipelineBuilder:
     def build_read_files_tarball_scan_stage(
         self,
         dir_path: Path,
-        tar_base_dir: Optional[str] = None,
-        exclude_file_names: Optional[List[str]] = None,
+        tar_base_dir: str | None = None,
+        exclude_file_names: list[str] | None = None,
     ) -> "PipelineBuilder":
         """
         Build reading files to tarball stage.
@@ -137,7 +137,7 @@ class PipelineBuilder:
         return self
 
     def build_read_files_tarball_stage(
-        self, dir_path: Path, file_relative_paths: List[Path]
+        self, dir_path: Path, file_relative_paths: list[Path]
     ) -> "PipelineBuilder":
         """
         Build reading files to tarball stage.
@@ -155,7 +155,7 @@ class PipelineBuilder:
         return self
 
     def build_read_data_tarball_stage(
-        self, file_names: List[str], data_list: List[bytes]
+        self, file_names: list[str], data_list: list[bytes]
     ) -> "PipelineBuilder":
         """
         Build reading in-memory data to tarball stage.
@@ -267,7 +267,7 @@ class PipelineBuilder:
         return self
 
     def build_delete_files_scan_stage(
-        self, base_path: Path, exclude_file_names: Optional[List[str]] = None
+        self, base_path: Path, exclude_file_names: list[str] | None = None
     ) -> "PipelineBuilder":
         """
         Build deleting files stage.
@@ -281,7 +281,7 @@ class PipelineBuilder:
         )
         return self
 
-    def build_delete_files_stage(self, files: List[Path]) -> "PipelineBuilder":
+    def build_delete_files_stage(self, files: list[Path]) -> "PipelineBuilder":
         """
         Build deleting files stage.
         """
@@ -346,9 +346,7 @@ class PipelineBuilder:
         self.append(thread_map(CollectDataStage()))
         return self
 
-    def build_write_file_stage(
-        self, file_path: Union[Path, BinaryIO]
-    ) -> "PipelineBuilder":
+    def build_write_file_stage(self, file_path: Path | BinaryIO) -> "PipelineBuilder":
         """
         Build writing single file stage.
         """

--- a/ch_backup/storage/async_pipeline/pipeline_executor.py
+++ b/ch_backup/storage/async_pipeline/pipeline_executor.py
@@ -9,11 +9,7 @@ from typing import (
     AnyStr,
     BinaryIO,
     Callable,
-    List,
-    Optional,
     Sequence,
-    Tuple,
-    Union,
 )
 
 from ch_backup.profile import profile
@@ -46,7 +42,7 @@ class PipelineExecutor:
 
     def __init__(self, config: dict) -> None:
         self._config = config
-        self._exec_pool: Optional[ProcessExecPool] = None
+        self._exec_pool: ProcessExecPool | None = None
 
         worker_count = self._config["multiprocessing"].get("workers")
         if worker_count:
@@ -68,8 +64,8 @@ class PipelineExecutor:
     # pylint: disable=too-many-positional-arguments
     def upload_data_tarball(
         self,
-        file_names: List[str],
-        data_list: List[bytes],
+        file_names: list[str],
+        data_list: list[bytes],
         remote_path: str,
         is_async: bool,
         encryption: bool,
@@ -129,9 +125,9 @@ class PipelineExecutor:
         encryption: bool,
         delete: bool,
         compression: bool,
-        tar_base_dir: Optional[str] = None,
-        exclude_file_names: Optional[List[str]] = None,
-        callback: Optional[Callable] = None,
+        tar_base_dir: str | None = None,
+        exclude_file_names: list[str] | None = None,
+        callback: Callable | None = None,
     ) -> None:
         """
         Archive to tarball and upload files from local filesystem.
@@ -161,8 +157,8 @@ class PipelineExecutor:
         encryption: bool,
         delete: bool,
         compression: bool,
-        files: List[str],
-        callback: Optional[Callable] = None,
+        files: list[str],
+        callback: Callable | None = None,
     ) -> None:
         """
         Archive to tarball and upload files from local filesystem.
@@ -200,7 +196,7 @@ class PipelineExecutor:
         is_async: bool,
         encryption: bool,
         compression: bool,
-    ) -> List[Tuple[str, bytes]]:
+    ) -> list[tuple[str, bytes]]:
         """
         Download tarball from storage and return list of (filename, data) pairs.
         """
@@ -218,7 +214,7 @@ class PipelineExecutor:
     def download_file(
         self,
         remote_path: str,
-        local_path: Union[str, BinaryIO],
+        local_path: str | BinaryIO,
         is_async: bool,
         encryption: bool,
         compression: bool,
@@ -246,7 +242,7 @@ class PipelineExecutor:
         is_async: bool,
         encryption: bool,
         compression: bool,
-        callback: Optional[Callable],
+        callback: Callable | None,
     ) -> None:
         """
         Download and unarchive tarball to files on local filesystem.
@@ -291,7 +287,7 @@ class PipelineExecutor:
         job_id: str,
         pipeline: Callable,
         is_async: bool,
-        callback: Optional[Callable] = None,
+        callback: Callable | None = None,
     ) -> Any:
         """
         Run pipeline inplace or schedule for exec in process pool

--- a/ch_backup/storage/async_pipeline/pipelines.py
+++ b/ch_backup/storage/async_pipeline/pipelines.py
@@ -9,11 +9,7 @@ from typing import (
     AnyStr,
     BinaryIO,
     Iterator,
-    List,
-    Optional,
     Sequence,
-    Tuple,
-    Union,
 )
 
 from ch_backup import logging
@@ -54,8 +50,8 @@ def upload_data_pipeline(
 # pylint: disable=too-many-positional-arguments
 def upload_data_tarball_pipeline(
     config: dict,
-    file_names: List[str],
-    data_list: List[bytes],
+    file_names: list[str],
+    data_list: list[bytes],
     remote_path: str,
     encrypt: bool,
     compress: bool,
@@ -111,8 +107,8 @@ def upload_files_tarball_scan_pipeline(
     encrypt: bool,
     delete_after: bool,
     compression: bool,
-    tar_base_dir: Optional[str] = None,
-    exclude_file_names: Optional[List[str]] = None,
+    tar_base_dir: str | None = None,
+    exclude_file_names: list[str] | None = None,
 ) -> None:
     """
     Entrypoint of upload files tarball pipeline.
@@ -146,7 +142,7 @@ def upload_files_tarball_scan_pipeline(
 def upload_files_tarball_pipeline(
     config: dict,
     base_path: Path,
-    file_relative_paths: List[Path],
+    file_relative_paths: list[Path],
     remote_path: str,
     encrypt: bool,
     delete_after: bool,
@@ -196,7 +192,7 @@ def download_data_tarball_pipeline(
     remote_path: str,
     decrypt: bool,
     decompress: bool,
-) -> List[Tuple[str, bytes]]:
+) -> list[tuple[str, bytes]]:
     """
     Entrypoint of download data tarball pipeline.
     Downloads tarball and unpacks it into list of (filename, data) pairs.
@@ -216,7 +212,7 @@ def download_data_tarball_pipeline(
 def download_file_pipeline(
     config: dict,
     remote_path: str,
-    local_path: Union[Path, BinaryIO],
+    local_path: Path | BinaryIO,
     decrypt: bool,
     decompress: bool,
 ) -> None:
@@ -296,7 +292,7 @@ def run_and_return_first(pipeline: PypelnStage) -> Any:
     return result
 
 
-def run_and_collect_all(pipeline: PypelnStage) -> List[Any]:
+def run_and_collect_all(pipeline: PypelnStage) -> list[Any]:
     """
     Run pipeline until it is complete and collect all results.
     """

--- a/ch_backup/storage/async_pipeline/stages/compression/compress_stage.py
+++ b/ch_backup/storage/async_pipeline/stages/compression/compress_stage.py
@@ -2,8 +2,6 @@
 Compressing stage.
 """
 
-from typing import Optional
-
 from ch_backup.compression.base import BaseCompression
 from ch_backup.storage.async_pipeline.base_pipeline.handler import Handler
 from ch_backup.storage.async_pipeline.stages.types import StageType
@@ -19,13 +17,13 @@ class CompressStage(Handler):
     def __init__(self, compressor: BaseCompression) -> None:
         self._compressor = compressor
 
-    def __call__(self, data: bytes, index: int) -> Optional[bytes]:
+    def __call__(self, data: bytes, index: int) -> bytes | None:
         compressed_data = self._compressor.compress(data)
         if len(compressed_data) > 0:
             return compressed_data
         return None
 
-    def on_done(self) -> Optional[bytes]:
+    def on_done(self) -> bytes | None:
         compressed_data = self._compressor.flush_compress()
         if len(compressed_data) > 0:
             return compressed_data

--- a/ch_backup/storage/async_pipeline/stages/compression/decompress_stage.py
+++ b/ch_backup/storage/async_pipeline/stages/compression/decompress_stage.py
@@ -2,8 +2,6 @@
 Decompressing stage.
 """
 
-from typing import Optional
-
 from ch_backup.compression.base import BaseCompression
 from ch_backup.storage.async_pipeline.base_pipeline.handler import Handler
 from ch_backup.storage.async_pipeline.stages.types import StageType
@@ -19,13 +17,13 @@ class DecompressStage(Handler):
     def __init__(self, compressor: BaseCompression) -> None:
         self._compressor = compressor
 
-    def __call__(self, data: bytes, index: int) -> Optional[bytes]:
+    def __call__(self, data: bytes, index: int) -> bytes | None:
         decompressed_data = self._compressor.decompress(data)
         if len(decompressed_data) > 0:
             return decompressed_data
         return None
 
-    def on_done(self) -> Optional[bytes]:
+    def on_done(self) -> bytes | None:
         decompressed_data = self._compressor.flush_decompress()
         if len(decompressed_data) > 0:
             return decompressed_data

--- a/ch_backup/storage/async_pipeline/stages/filesystem/delete_files_stage.py
+++ b/ch_backup/storage/async_pipeline/stages/filesystem/delete_files_stage.py
@@ -3,7 +3,7 @@ Deleting files stage.
 """
 
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any
 
 from ch_backup.storage.async_pipeline.base_pipeline.handler import Handler
 from ch_backup.storage.async_pipeline.stages.types import StageType
@@ -22,7 +22,7 @@ class DeleteFilesScanStage(Handler):
         self,
         config: dict,
         base_path: Path,
-        exclude_file_names: Optional[List[str]] = None,
+        exclude_file_names: list[str] | None = None,
     ) -> None:
         self._config = config
         self._base_path = base_path
@@ -44,7 +44,7 @@ class DeleteFilesStage(Handler):
 
     stype = StageType.FILESYSTEM
 
-    def __init__(self, config: dict, files: List[Path]) -> None:
+    def __init__(self, config: dict, files: list[Path]) -> None:
         self._config = config
         self._files = files
 

--- a/ch_backup/storage/async_pipeline/stages/filesystem/read_file_stage.py
+++ b/ch_backup/storage/async_pipeline/stages/filesystem/read_file_stage.py
@@ -3,7 +3,7 @@ Read file stage.
 """
 
 from pathlib import Path
-from typing import BinaryIO, Iterable, Optional
+from typing import BinaryIO, Iterable
 
 from ch_backup.storage.async_pipeline.base_pipeline.handler import InputHandler
 from ch_backup.storage.async_pipeline.stages.types import StageType
@@ -19,7 +19,7 @@ class ReadFileStage(InputHandler):
     def __init__(self, config: dict, file_path: Path) -> None:
         self._chunk_size = config["chunk_size"]
         self._file_path = file_path
-        self._fobj: Optional[BinaryIO] = None
+        self._fobj: BinaryIO | None = None
 
     def on_start(self) -> None:
         self._fobj = self._file_path.open(mode="rb")

--- a/ch_backup/storage/async_pipeline/stages/filesystem/read_files_tarball_stage.py
+++ b/ch_backup/storage/async_pipeline/stages/filesystem/read_files_tarball_stage.py
@@ -6,7 +6,7 @@ import tarfile
 import time
 from io import BytesIO
 from pathlib import Path
-from typing import Any, BinaryIO, Iterable, Iterator, List, Optional
+from typing import Any, BinaryIO, Iterable, Iterator
 
 from ch_backup.storage.async_pipeline.base_pipeline.handler import InputHandler
 from ch_backup.storage.async_pipeline.stages.types import StageType
@@ -45,12 +45,12 @@ class ReadFilesTarballStageBase(InputHandler):
         self,
         config: dict,
         base_path: Path,
-        tar_base_dir: Optional[str] = None,
+        tar_base_dir: str | None = None,
     ) -> None:
         self._chunk_size = config["chunk_size"]
         self._base_path = base_path
         self._file_source: Iterable[Any] = []
-        self._tar_base_dir: Optional[str] = tar_base_dir
+        self._tar_base_dir: str | None = tar_base_dir
 
     def __call__(self) -> Iterator[bytes]:
         """
@@ -96,8 +96,8 @@ class ReadFilesTarballScanStage(ReadFilesTarballStageBase):
         self,
         config: dict,
         base_path: Path,
-        tar_base_dir: Optional[str] = None,
-        exclude_file_names: Optional[List[str]] = None,
+        tar_base_dir: str | None = None,
+        exclude_file_names: list[str] | None = None,
     ) -> None:
         super().__init__(config, base_path, tar_base_dir)
         self._file_source = scan_dir_files(self._base_path, exclude_file_names)
@@ -112,8 +112,8 @@ class ReadFilesTarballStage(ReadFilesTarballStageBase):
         self,
         config: dict,
         base_path: Path,
-        file_relative_paths: List[Path],
-        tar_base_dir: Optional[str] = None,
+        file_relative_paths: list[Path],
+        tar_base_dir: str | None = None,
     ) -> None:
         super().__init__(config, base_path, tar_base_dir)
         self._file_source = file_relative_paths
@@ -127,8 +127,8 @@ class ReadDataTarballStage(ReadFilesTarballStageBase):
     def __init__(
         self,
         config: dict,
-        file_names: List[str],
-        data_list: List[bytes],
+        file_names: list[str],
+        data_list: list[bytes],
     ) -> None:
         # Call parent with dummy base_path since we don't use filesystem
         super().__init__(config, Path("."))

--- a/ch_backup/storage/async_pipeline/stages/filesystem/write_file_stage.py
+++ b/ch_backup/storage/async_pipeline/stages/filesystem/write_file_stage.py
@@ -3,7 +3,7 @@ Write file stage.
 """
 
 from pathlib import Path
-from typing import BinaryIO, Optional, Union
+from typing import BinaryIO
 
 from ch_backup.storage.async_pipeline.base_pipeline.handler import Handler
 from ch_backup.storage.async_pipeline.stages.types import StageType
@@ -16,8 +16,8 @@ class WriteFileStage(Handler):
 
     stype = StageType.FILESYSTEM
 
-    def __init__(self, file: Union[Path, BinaryIO]) -> None:
-        self._fobj: Optional[BinaryIO] = None
+    def __init__(self, file: Path | BinaryIO) -> None:
+        self._fobj: BinaryIO | None = None
         self._file = file
 
     def on_start(self) -> None:

--- a/ch_backup/storage/async_pipeline/stages/filesystem/write_files_stage.py
+++ b/ch_backup/storage/async_pipeline/stages/filesystem/write_files_stage.py
@@ -5,7 +5,7 @@ Writing files from TAR stream stage.
 from enum import Enum
 from pathlib import Path
 from tarfile import BLOCKSIZE, ENCODING, GNUTYPE_LONGNAME, NUL, TarInfo
-from typing import IO, Any, Iterator, Optional
+from typing import IO, Any, Iterator
 
 from ch_backup.storage.async_pipeline.base_pipeline.bytes_fifo import BytesFIFO
 from ch_backup.storage.async_pipeline.base_pipeline.handler import Handler
@@ -45,8 +45,8 @@ class TarStreamProcessorBase(Handler):
         self._state: State = State.READ_HEADER
 
         self._bytes_to_process: int = 0
-        self._tarinfo: Optional[TarInfo] = None
-        self._name_from_buffer: Optional[bytes] = None
+        self._tarinfo: TarInfo | None = None
+        self._name_from_buffer: bytes | None = None
 
     def __call__(self, data: bytes, index: int) -> None:
         written = self._tarstream.write(data)
@@ -156,7 +156,7 @@ class WriteFilesStage(TarStreamProcessorBase):
     def __init__(self, config: dict, dir_path: Path, buffer_size: int) -> None:
         super().__init__(config, buffer_size)
         self._dir: Path = dir_path
-        self._fobj: Optional[IO] = None
+        self._fobj: IO | None = None
 
     def _on_file_complete(self) -> None:
         if self._fobj:

--- a/ch_backup/storage/async_pipeline/stages/storage/download_storage_stage.py
+++ b/ch_backup/storage/async_pipeline/stages/storage/download_storage_stage.py
@@ -2,7 +2,7 @@
 Downloading object from a storage stage.
 """
 
-from typing import Iterable, Optional
+from typing import Iterable
 
 from ch_backup.storage.async_pipeline.base_pipeline.handler import InputHandler
 from ch_backup.storage.async_pipeline.stages.types import StageType
@@ -22,7 +22,7 @@ class DownloadStorageStage(InputHandler):
         self._chunk_size = config["chunk_size"]
         self._loader = loader
         self._remote_path = remote_path
-        self._download_id: Optional[str] = None
+        self._download_id: str | None = None
 
     def on_start(self) -> None:
         self._download_id = self._loader.create_multipart_download(self._remote_path)

--- a/ch_backup/storage/async_pipeline/stages/storage/multipart_storage_uploading_stage.py
+++ b/ch_backup/storage/async_pipeline/stages/storage/multipart_storage_uploading_stage.py
@@ -3,7 +3,6 @@ Multipart uploading to storage stage.
 """
 
 from dataclasses import dataclass
-from typing import Optional
 
 from ch_backup.storage.async_pipeline.base_pipeline.handler import Handler
 from ch_backup.storage.async_pipeline.stages.types import StageType
@@ -21,7 +20,7 @@ class UploadingPart(Slotted):
 
     __slots__ = "data", "upload_id"
     data: bytes
-    upload_id: Optional[str]
+    upload_id: str | None
 
 
 class StartMultipartUploadStage(Handler):
@@ -43,7 +42,7 @@ class StartMultipartUploadStage(Handler):
         self._config = config
         self._loader = loader
         self._remote_path = remote_path
-        self._upload_id: Optional[str] = None
+        self._upload_id: str | None = None
         self._chunk_size = chunk_size
 
     def __call__(self, data: bytes, index: int) -> UploadingPart:
@@ -103,7 +102,7 @@ class CompleteMultipartUploadStage(Handler):
         self._config = config
         self._loader = loader
         self._remote_path = remote_path
-        self._upload_id: Optional[str] = None
+        self._upload_id: str | None = None
 
     def __call__(self, part: UploadingPart, index: int) -> None:
         if self._upload_id is None and part.upload_id:

--- a/ch_backup/storage/async_pipeline/suppress_exceptions.py
+++ b/ch_backup/storage/async_pipeline/suppress_exceptions.py
@@ -2,12 +2,12 @@
 Suppressing pipeline exception auxiliary function.
 """
 
-from typing import Any, Callable, Sequence, Type, TypeVar
+from typing import Any, Callable, Sequence, TypeVar
 
 from ch_backup import logging
 
 ExceptionT = TypeVar("ExceptionT", bound=Exception)
-ExceptionTypes = Sequence[Type[ExceptionT]]
+ExceptionTypes = Sequence[type[ExceptionT]]
 
 
 def suppress_exceptions(func: Callable, exceptions: ExceptionTypes = ()) -> Any:

--- a/ch_backup/storage/engine/base.py
+++ b/ch_backup/storage/engine/base.py
@@ -3,7 +3,7 @@ Interfaces for storage engines.
 """
 
 from abc import ABCMeta, abstractmethod
-from typing import Optional, Sequence
+from typing import Sequence
 
 
 class StorageEngine(metaclass=ABCMeta):
@@ -80,7 +80,7 @@ class PipeLineCompatibleStorageEngine(StorageEngine):
         data: bytes,
         remote_path: str,
         upload_id: str,
-        part_num: Optional[int] = None,
+        part_num: int | None = None,
     ) -> None:
         """
         Upload data part in multipart upload.

--- a/ch_backup/storage/engine/s3/s3_client_factory.py
+++ b/ch_backup/storage/engine/s3/s3_client_factory.py
@@ -5,7 +5,7 @@ S3 client factory.
 import socket
 import threading
 from functools import wraps
-from typing import Callable, Optional, Union
+from typing import Callable
 
 import boto3
 import requests
@@ -36,9 +36,7 @@ class S3ClientFactory:
         )
 
     @retry((S3BalancerUnknownHost, requests.RequestException))
-    def _resolve_proxies(
-        self, resolver_path: str, proxy_port: int
-    ) -> Union[dict, None]:
+    def _resolve_proxies(self, resolver_path: str, proxy_port: int) -> dict | None:
         """
         Get proxy host name via a special handler
         """
@@ -106,7 +104,7 @@ class S3ClientCachedFactory:
 
     def __init__(self, s3_client_factory: S3ClientFactory) -> None:
         self._s3_client_factory = s3_client_factory
-        self._cached_s3_client: Optional[S3Client] = None
+        self._cached_s3_client: S3Client | None = None
 
     @synchronized
     def create_s3_client(self, cached: bool = True) -> S3Client:

--- a/ch_backup/storage/engine/s3/s3_engine.py
+++ b/ch_backup/storage/engine/s3/s3_engine.py
@@ -5,7 +5,7 @@ S3 storage engine.
 import os
 import time
 from tempfile import TemporaryFile
-from typing import Optional, Sequence
+from typing import Sequence
 
 import requests
 from botocore.exceptions import ClientError
@@ -185,7 +185,7 @@ class S3StorageEngine(PipeLineCompatibleStorageEngine, metaclass=S3RetryMeta):
         data: bytes,
         remote_path: str,
         upload_id: str,
-        part_num: Optional[int] = None,
+        part_num: int | None = None,
     ) -> None:
         self._multipart_uploader.upload_part(
             data, remote_path, upload_id, part_num=part_num
@@ -208,7 +208,7 @@ class S3StorageEngine(PipeLineCompatibleStorageEngine, metaclass=S3RetryMeta):
 
         return download_id
 
-    def download_part(self, download_id: str, part_len: int = None) -> Optional[bytes]:
+    def download_part(self, download_id: str, part_len: int = None) -> bytes | None:
         if not part_len:
             part_len = self.DEFAULT_DOWNLOAD_PART_LEN
 

--- a/ch_backup/storage/engine/s3/s3_multipart_uploader.py
+++ b/ch_backup/storage/engine/s3/s3_multipart_uploader.py
@@ -5,7 +5,6 @@ S3 multipart uploader.
 import operator
 import threading
 import time
-from typing import Dict, Optional
 
 from ch_backup.storage.engine.s3.s3_client_factory import S3ClientCachedFactory
 from ch_backup.type_hints.boto3.s3 import S3Client
@@ -23,7 +22,7 @@ class S3MultipartUploader:
         self._s3_client_factory = s3_client_factory
         self._lock = threading.Lock()
 
-        self._uploads: Dict[str, dict] = {}
+        self._uploads: dict[str, dict] = {}
 
     @property
     def _s3_client(self) -> S3Client:
@@ -52,7 +51,7 @@ class S3MultipartUploader:
         data: bytes,
         remote_path: str,
         upload_id: str,
-        part_num: Optional[int] = None,
+        part_num: int | None = None,
     ) -> None:
         """
         Upload part to S3 storage for specified multipart upload.

--- a/ch_backup/storage/engine/s3/s3_retry.py
+++ b/ch_backup/storage/engine/s3/s3_retry.py
@@ -8,7 +8,7 @@ from http.client import HTTPException
 from inspect import isfunction
 from random import uniform
 from time import sleep
-from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from botocore.exceptions import BotoCoreError, ClientError
 from urllib3.exceptions import HTTPError
@@ -66,7 +66,7 @@ class S3RetryMeta(ABCMeta):
 
 # pylint: disable=too-many-positional-arguments
 def retry(
-    exception_types: Union[type, tuple] = Exception,
+    exception_types: type | tuple = Exception,
     max_attempts: int = 5,
     max_interval: float = 5,
     multiplier: float = 0.5,
@@ -98,7 +98,7 @@ class RetryExponential:
     # pylint: disable=too-many-positional-arguments
     def __init__(
         self,
-        exception_types: Union[type, tuple] = Exception,
+        exception_types: type | tuple = Exception,
         max_attempts: int = 5,
         max_interval: float = 5,
         multiplier: float = 0.5,

--- a/ch_backup/storage/loader.py
+++ b/ch_backup/storage/loader.py
@@ -3,7 +3,7 @@ Module providing API for storage management (upload and download data, check
 remote path on existence, etc.).
 """
 
-from typing import BinaryIO, Callable, List, Optional, Sequence, Union
+from typing import BinaryIO, Callable, Sequence
 
 from ch_backup.storage.async_pipeline.pipeline_executor import PipelineExecutor
 from ch_backup.storage.engine import get_storage_engine
@@ -43,8 +43,8 @@ class StorageLoader:
     # pylint: disable=too-many-positional-arguments
     def upload_data_tarball(
         self,
-        file_names: List[str],
-        data_list: List[bytes],
+        file_names: list[str],
+        data_list: list[bytes],
         remote_path: str,
         is_async: bool = False,
         encryption: bool = False,
@@ -95,12 +95,12 @@ class StorageLoader:
         self,
         dir_path: str,
         remote_path: str,
-        tar_base_dir: Optional[str] = None,
-        exclude_file_names: Optional[List[str]] = None,
+        tar_base_dir: str | None = None,
+        exclude_file_names: list[str] | None = None,
         is_async: bool = False,
         encryption: bool = False,
         delete: bool = False,
-        callback: Optional[Callable] = None,
+        callback: Callable | None = None,
         compression: bool = False,
     ) -> str:
         """
@@ -127,11 +127,11 @@ class StorageLoader:
         self,
         dir_path: str,
         remote_path: str,
-        files: List[str],
+        files: list[str],
         is_async: bool = False,
         encryption: bool = False,
         delete: bool = False,
-        callback: Optional[Callable] = None,
+        callback: Callable | None = None,
         compression: bool = False,
     ) -> str:
         """
@@ -188,7 +188,7 @@ class StorageLoader:
     def download_file(
         self,
         remote_path: str,
-        local_path: Union[str, BinaryIO],
+        local_path: str | BinaryIO,
         is_async: bool = False,
         encryption: bool = False,
         compression: bool = False,
@@ -212,7 +212,7 @@ class StorageLoader:
         is_async: bool = False,
         encryption: bool = False,
         compression: bool = False,
-        callback: Optional[Callable] = None,
+        callback: Callable | None = None,
     ) -> None:
         """
         Download file to local filesystem.

--- a/ch_backup/util.py
+++ b/ch_backup/util.py
@@ -25,9 +25,7 @@ from typing import (
     Callable,
     Iterable,
     Iterator,
-    Type,
     TypeVar,
-    Union,
 )
 
 import tenacity
@@ -259,7 +257,7 @@ def wait_for(
 
 
 def retry(
-    exception_types: Union[type, tuple] = Exception,
+    exception_types: type | tuple = Exception,
     max_attempts: int = 5,
     max_interval: float = 5,
     retry_if: tenacity.retry_base = tenacity.retry_always,
@@ -421,7 +419,7 @@ def exhaust_iterator(iterator: Iterator) -> None:
     collections.deque(iterator, maxlen=0)
 
 
-def dataclass_from_dict(type_: Type[T], data: dict) -> T:
+def dataclass_from_dict(type_: type[T], data: dict) -> T:
     """
     Create dataclass instance from dictionary.
 

--- a/ch_backup/util.py
+++ b/ch_backup/util.py
@@ -25,9 +25,6 @@ from typing import (
     Callable,
     Iterable,
     Iterator,
-    List,
-    Optional,
-    Tuple,
     Type,
     TypeVar,
     Union,
@@ -89,7 +86,7 @@ def chown_file(user: str, group: str, file_path: str) -> None:
     shutil.chown(file_path, user, group)
 
 
-def list_dir_files(dir_path: str) -> List[str]:
+def list_dir_files(dir_path: str) -> list[str]:
     """
     Returns paths of all files of directory (recursively), relative to its path
     """
@@ -100,7 +97,7 @@ def list_dir_files(dir_path: str) -> List[str]:
 
 
 def scan_dir_files(
-    dir_path: Path, exclude_file_names: Optional[List[str]] = None
+    dir_path: Path, exclude_file_names: list[str] | None = None
 ) -> Iterable[str]:
     """
     Yields relative file paths in a given directory and excludes files with given names
@@ -132,7 +129,7 @@ def scan_dir_files(
     yield from scan_recursive(dir_path)
 
 
-def dir_is_empty(dir_path: str, exclude_file_names: Optional[List[str]] = None) -> bool:
+def dir_is_empty(dir_path: str, exclude_file_names: list[str] | None = None) -> bool:
     """
     Returns True if directory contains some files other than excluded
     """
@@ -292,7 +289,7 @@ def retry(
     )
 
 
-def get_table_zookeeper_paths(tables: Iterable) -> Iterable[Tuple]:
+def get_table_zookeeper_paths(tables: Iterable) -> Iterable[tuple]:
     """
     Parse ZooKeeper path from create statement.
     """
@@ -310,7 +307,7 @@ def get_table_zookeeper_paths(tables: Iterable) -> Iterable[Tuple]:
     return result
 
 
-def get_database_zookeeper_paths(databases: Iterable) -> Iterable[Tuple]:
+def get_database_zookeeper_paths(databases: Iterable) -> Iterable[tuple]:
     """
     Parse ZooKeeper path from database create statement and return path to database and shard from schema.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ ignore-words-list = "sav,fpr"
 
 
 [tool.ruff]
-lint.select = ["E", "F", "W", "A", "S"]
+lint.select = ["E", "F", "W", "A", "S", "UP006", "UP007", "UP045"]
 lint.ignore = [
     "A003",  # "Class attribute is shadowing a Python builtin"
     "A005",  # Module `logging` shadows a Python standard-library module

--- a/tests/integration/modules/ch_backup_cli.py
+++ b/tests/integration/modules/ch_backup_cli.py
@@ -5,7 +5,7 @@ Interface to ch-backup command-line tool.
 import json
 import os
 from copy import copy
-from typing import Sequence, Set, Union
+from typing import Sequence
 from urllib.parse import quote
 
 import yaml
@@ -18,7 +18,7 @@ from .typing import ContextT
 CH_BACKUP_CLI_PATH = "/usr/local/bin/ch-backup"
 CH_BACKUP_CONF_PATH = "/etc/yandex/ch-backup/ch-backup.conf"
 
-BackupId = Union[int, str]
+BackupId = int | str
 
 
 class Backup:
@@ -169,7 +169,7 @@ class Backup:
         """
         backup_path = self.get_backup_path(path_root)
         cloud_stage_disks = set(self._metadata["cloud_storage"]["disks"])
-        file_paths: Set[str] = set()
+        file_paths: set[str] = set()
         for db_name, db_obj in self._metadata["databases"].items():
             for table_name, table_obj in db_obj["tables"].items():
                 for part_name, part_obj in table_obj["parts"].items():

--- a/tests/integration/modules/clickhouse.py
+++ b/tests/integration/modules/clickhouse.py
@@ -5,7 +5,7 @@ ClickHouse client.
 import logging
 from copy import copy
 from datetime import datetime, timedelta
-from typing import Any, List, Sequence, Tuple, Union
+from typing import Any, Sequence
 from urllib.parse import urljoin
 
 from requests import HTTPError, Session
@@ -149,7 +149,7 @@ class ClickhouseClient:
                 # Make all possible merges to make tests more determined
                 self._query("POST", f"OPTIMIZE TABLE `{db_name}`.`{table_name}`")
 
-    def get_all_user_data(self) -> Tuple[int, dict]:
+    def get_all_user_data(self) -> tuple[int, dict]:
         """
         Retrieve all user data.
         """
@@ -303,7 +303,7 @@ class ClickhouseClient:
         method: str,
         query: str = None,
         url: str = None,
-        data: Union[bytes, str] = None,
+        data: bytes | str | None = None,
     ) -> Any:
         if url:
             url = urljoin(self._url, url)
@@ -361,14 +361,14 @@ class ClickhouseClient:
         """
         Generate test rows.
         """
-        rows: List[str] = []
+        rows: list[str] = []
 
         if str_prefix is None:
             str_prefix = ""
         else:
             str_prefix = f"{str_prefix}_"
 
-        dates: List[datetime] = []
+        dates: list[datetime] = []
         dt_now = datetime.utcnow()
         # PARTITION BY date
         for i in range(partitions_count):

--- a/tests/integration/modules/docker.py
+++ b/tests/integration/modules/docker.py
@@ -7,7 +7,7 @@ import os
 import random
 import re
 import tarfile
-from typing import List, Sequence, Tuple
+from typing import Sequence
 from urllib.parse import urlparse
 
 import docker
@@ -40,7 +40,7 @@ def get_container(context: ContextT, prefix: str) -> Container:
     return DOCKER_API.containers.get(f"{prefix}.{network_name}")
 
 
-def get_exposed_port(container: Container, port: int) -> Tuple[str, int]:
+def get_exposed_port(container: Container, port: int) -> tuple[str, int]:
     """
     Get pair of (host, port) for connection to exposed port.
     """
@@ -91,7 +91,7 @@ def copy_container_dir(
     buffer.seek(0)
 
     with tarfile.open(mode="r", fileobj=buffer) as tar:
-        members: List[tarfile.TarInfo] = []
+        members: list[tarfile.TarInfo] = []
         for member in tar.getmembers():
             if member.type == tarfile.SYMTYPE:
                 continue

--- a/tests/integration/modules/s3.py
+++ b/tests/integration/modules/s3.py
@@ -3,7 +3,6 @@ S3 client.
 """
 
 import logging
-from typing import List, Optional
 
 import boto3
 from botocore.client import Config
@@ -18,7 +17,7 @@ class S3Client:
     S3 client.
     """
 
-    def __init__(self, context: ContextT, bucket: Optional[str] = None) -> None:
+    def __init__(self, context: ContextT, bucket: str | None = None) -> None:
         config = context.conf["s3"]
         boto_config = config["boto_config"]
         self._s3_session = boto3.session.Session(
@@ -77,7 +76,7 @@ class S3Client:
         except ClientError:
             return False
 
-    def list_objects(self, prefix: str) -> List[str]:
+    def list_objects(self, prefix: str) -> list[str]:
         """
         List all objects with given prefix.
         """

--- a/tests/integration/modules/typing.py
+++ b/tests/integration/modules/typing.py
@@ -3,8 +3,7 @@ Type definitions.
 """
 
 from types import SimpleNamespace
-from typing import Union
 
 from behave.runner import Context
 
-ContextT = Union[Context, SimpleNamespace]
+ContextT = Context | SimpleNamespace

--- a/tests/integration/modules/zookeeper.py
+++ b/tests/integration/modules/zookeeper.py
@@ -3,7 +3,6 @@ ZooKeeper client calls
 """
 
 import logging
-from typing import List, Optional
 
 from kazoo.client import KazooClient
 from kazoo.exceptions import NodeExistsError, NoNodeError
@@ -65,7 +64,7 @@ def znode_exists(context: ContextT, node: str, zk_path: str) -> bool:
     return result
 
 
-def get_children_list(context: ContextT, node: str, zk_path: str) -> Optional[List]:
+def get_children_list(context: ContextT, node: str, zk_path: str) -> list | None:
     zk = _get_zookeeper_client(context, node)
     try:
         return zk.get_children(zk_path)

--- a/tests/unit/test_access.py
+++ b/tests/unit/test_access.py
@@ -2,7 +2,6 @@
 Access entities unit tests.
 """
 
-from typing import Optional
 from unittest import mock
 
 from ch_backup.backup_context import BackupContext
@@ -11,7 +10,7 @@ from ch_backup.zookeeper.zookeeper import ZookeeperCTL
 from tests.unit.utils import parametrize
 
 
-def zookeeper_mock(config: Optional[dict] = None) -> ZookeeperCTL:
+def zookeeper_mock(config: dict | None = None) -> ZookeeperCTL:
     config = config or {}
     default = {"hosts": [], "root_path": "/"}
     with mock.patch("ch_backup.zookeeper.zookeeper.KazooClient"):

--- a/tests/unit/test_backup_tables.py
+++ b/tests/unit/test_backup_tables.py
@@ -1,8 +1,5 @@
-from dataclasses import dataclass
-from unittest.mock import MagicMock, Mock, patch
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import replace
-from typing import List, Optional
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
@@ -113,11 +110,11 @@ _EXISTS_ERROR = ClickhouseError("Cannot check table existence")
 )
 # pylint: disable=too-many-locals
 def test_backup_table_skipping_if_metadata_updated_during_backup(
-    metadata_after_freeze: List[Optional[TableMetadataChangeTime]],
-    freeze_error: Optional[ClickhouseError],
+    metadata_after_freeze: list[TableMetadataChangeTime | None],
+    freeze_error: ClickhouseError | None,
     table_exists: bool | ClickhouseError,
-    expected_error: Optional[ClickhouseError],
-    expected_databases: List[str],
+    expected_error: ClickhouseError | None,
+    expected_databases: list[str],
 ) -> None:
     table_name = "table1"
     db1_name = "db1"
@@ -202,9 +199,7 @@ def test_backup_table_skipping_if_metadata_updated_during_backup(
         for tables, after in zip(tables_by_db.values(), metadata_after_freeze)
         for table in tables
     }
-    error_context: AbstractContextManager[
-        Optional[pytest.ExceptionInfo[ClickhouseError]]
-    ]
+    error_context: AbstractContextManager[pytest.ExceptionInfo[ClickhouseError] | None]
     if expected_error:
         error_context = pytest.raises(ClickhouseError)
     else:

--- a/tests/unit/test_backup_tables.py
+++ b/tests/unit/test_backup_tables.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import List, Optional
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -57,7 +56,7 @@ _STAT_CTIME_CHANGED = FakeStatResult(
     ],
 )
 def test_backup_table_skipping_if_metadata_updated_during_backup(
-    fake_stats: List[FakeStatResult],
+    fake_stats: list[FakeStatResult],
     backups_expected_db1: int,
     backups_expected_db2: int,
 ) -> None:
@@ -155,7 +154,7 @@ class TestValidateUploadedParts:
 
     _BACKUP_NAME = "20181017T210300"
 
-    def _make_part(self, name: str, link: Optional[str] = None) -> PartMetadata:
+    def _make_part(self, name: str, link: str | None = None) -> PartMetadata:
         return PartMetadata(
             database="db1",
             table="table1",

--- a/tests/unit/test_bytes_fifo.py
+++ b/tests/unit/test_bytes_fifo.py
@@ -1,4 +1,4 @@
-from typing import ContextManager, Optional
+from typing import ContextManager
 
 import pytest
 
@@ -205,7 +205,7 @@ def test_resize(
     init_size: int,
     prefill_size: int,
     new_size: int,
-    exception: Optional[ContextManager],
+    exception: ContextManager | None,
 ) -> None:
     fifo = BytesFIFO(init_size)
 

--- a/tests/unit/test_calculators.py
+++ b/tests/unit/test_calculators.py
@@ -1,7 +1,6 @@
 import errno
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import List
 from unittest.mock import Mock
 
 import pytest
@@ -33,7 +32,7 @@ LENGTH_NAME = 100
     ],
 )
 def test_calc_aligned_data_size(
-    data_list: List[bytes], alignment: int, expected_size: int
+    data_list: list[bytes], alignment: int, expected_size: int
 ) -> None:
     assert calc_aligned_data_size(data_list, alignment) == expected_size
 
@@ -81,7 +80,7 @@ def test_calc_aligned_files_size_scan() -> None:
     ],
 )
 def test_calc_aligned_file_size(
-    file_sizes: List[int], alignment: int, expected_size: int
+    file_sizes: list[int], alignment: int, expected_size: int
 ) -> None:
     files = []
     for file_size in file_sizes:
@@ -114,7 +113,7 @@ def test_calc_aligned_file_size(
     ],
 )
 def test_calc_tarball_size(
-    name_lens: List[int], data_size: int, expected_size: int
+    name_lens: list[int], data_size: int, expected_size: int
 ) -> None:
     # Assuming name_lens size is less than 10
     names = [f"{i}" * name_len for i, name_len in enumerate(name_lens)]

--- a/tests/unit/test_disks.py
+++ b/tests/unit/test_disks.py
@@ -3,8 +3,6 @@ Unit tests disks module.
 """
 
 import unittest
-import unittest.mock
-from typing import List, Optional
 
 import xmltodict
 
@@ -214,7 +212,7 @@ def write_collector(x):
 
 def _make_temporary_disks(
     clickhouse_config_xml: str,
-    cloud_storage_disks: Optional[List[str]] = None,
+    cloud_storage_disks: list[str] | None = None,
 ) -> ClickHouseTemporaryDisks:
     """Helper: build ClickHouseTemporaryDisks with mocked dependencies."""
     context = BackupContext(DEFAULT_CONFIG)  # type: ignore[arg-type]

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -2,8 +2,6 @@
 Unit test for RateLimiter.
 """
 
-from typing import List
-
 import pytest
 
 from ch_backup.storage.async_pipeline.base_pipeline.rate_limiter import RateLimiter
@@ -50,7 +48,7 @@ def test_rate_limiter_extract(data_size: int, rate: int, expected_time: int) -> 
     ],
 )
 def test_rate_limiter_grand(
-    chunks_sizes: List[int], rate: int, expected_time: int
+    chunks_sizes: list[int], rate: int, expected_time: int
 ) -> None:
     timer = TimeMocker()
 

--- a/tests/unit/test_retry_exponetial.py
+++ b/tests/unit/test_retry_exponetial.py
@@ -2,8 +2,6 @@
 Unit test for RateLimiter.
 """
 
-from typing import List
-
 import pytest
 
 from ch_backup.storage.engine.s3.s3_retry import retry
@@ -40,7 +38,7 @@ from tests.unit.time_mocker import TimeMocker
     ],
 )
 def test_rate_limiter_extract(
-    max_attempts: int, max_interval: float, multiplier: float, expected_sleep_time: List
+    max_attempts: int, max_interval: float, multiplier: float, expected_sleep_time: list
 ) -> None:
     timer = TimeMocker()
     execution_count = 0

--- a/tests/unit/test_upload_part_observer.py
+++ b/tests/unit/test_upload_part_observer.py
@@ -1,5 +1,4 @@
 import copy
-from typing import List
 from unittest.mock import Mock, patch
 
 from ch_backup.backup.metadata import BackupMetadata, PartMetadata, TableMetadata
@@ -73,8 +72,8 @@ DB = Database(
     },
 )
 def test_observer(
-    times: List[int],
-    part_names: List[str],
+    times: list[int],
+    part_names: list[str],
     interval: int,
     expected_upload_metadata: int,
 ) -> None:

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -4,7 +4,6 @@ Testing utilities.
 
 from collections import defaultdict
 from datetime import timedelta
-from typing import List
 
 import pytest
 from deepdiff import DeepDiff
@@ -54,8 +53,8 @@ def parametrize(*tests):
     )
     ```
     """
-    ids: List[str] = []
-    argnames: List[str] = []
+    ids: list[str] = []
+    argnames: list[str] = []
     argvalues: list = []
     for test in tests:
         ids.append(test["id"])
@@ -82,7 +81,7 @@ def backup_metadata(
     age: timedelta = timedelta(minutes=1),
     schema_only: bool = False,
     databases: dict = None,
-    user_defined_functions: List[str] = None,
+    user_defined_functions: list[str] = None,
 ) -> BackupMetadata:
     """
     Build and return backup metadata.


### PR DESCRIPTION
## Summary by Sourcery

Replace legacy typing aliases with modern Python type annotation syntax throughout the project.

Enhancements:
- Modernize type annotations across the codebase by replacing legacy `typing` aliases with built-in generic and union syntax.

Build:
- Enable Ruff checks for modern type annotation rules.

Tests:
- Update unit and integration test annotations to use the modern built-in type syntax.