### PR TITLE
Validate ZooKeeper availability before restore

### DIFF
--- a/ch_backup/ch_backup.py
+++ b/ch_backup/ch_backup.py
@@ -17,8 +17,9 @@ from ch_backup.backup.deduplication import (
 from ch_backup.backup.metadata import BackupMetadata, BackupState, TableMetadata
 from ch_backup.backup.sources import BackupSources
 from ch_backup.backup_context import BackupContext
+from ch_backup.clickhouse.client import ClickhouseError
 from ch_backup.clickhouse.metadata_cleaner import MetadataCleaner, select_replica_drop
-from ch_backup.clickhouse.models import Database
+from ch_backup.clickhouse.models import Database, Table
 from ch_backup.config import Config
 from ch_backup.exceptions import (
     BackupNotFound,
@@ -324,6 +325,8 @@ class ClickhouseBackup:
         else:
             logging.debug("Picking all tables from backup.")
 
+        self._check_zookeeper_for_restore(sources, databases, tables)
+
         with self._context.locker(
             distributed=not sources.schema_only, operation="RESTORE"
         ):
@@ -340,6 +343,65 @@ class ClickhouseBackup:
                 keep_going=keep_going,
                 restore_tables_in_replicated_database=restore_tables_in_replicated_database,
             )
+
+    def _check_zookeeper_for_restore(
+        self,
+        sources: BackupSources,
+        databases: Sequence[str],
+        tables: Sequence[TableMetadata],
+    ) -> None:
+        """Fail early if selected schemas require unavailable ZooKeeper or Keeper."""
+        if not sources.schemas_included():
+            return
+
+        if self._context.config["force_non_replicated"]:
+            return
+
+        replicated_databases = [
+            database
+            for database in (
+                self._context.backup_meta.get_database(name) for name in databases
+            )
+            if database.is_replicated_db_engine()
+        ]
+
+        tables_to_restore = tables or [
+            table
+            for database in databases
+            for table in self._context.backup_meta.get_tables(database)
+        ]
+        replicated_tables = [
+            table
+            for table in tables_to_restore
+            if Table.engine_is_replicated(table.engine)
+        ]
+
+        if not replicated_databases and not replicated_tables:
+            return
+
+        try:
+            self._context.ch_ctl.check_zookeeper_available()
+        except ClickhouseError as error:
+            replicated_objects = []
+            if replicated_databases:
+                replicated_objects.append(
+                    "databases: "
+                    + ", ".join(
+                        f"`{database.name}`" for database in replicated_databases
+                    )
+                )
+            if replicated_tables:
+                replicated_objects.append(
+                    "tables: "
+                    + ", ".join(
+                        f"`{table.database}`.`{table.name}`"
+                        for table in replicated_tables
+                    )
+                )
+            raise ClickhouseBackupError(
+                f"Restore requires ZooKeeper or ClickHouse Keeper because we have replicated {', '.join(replicated_objects)}. "
+                f"Availability check through ClickHouse failed: {error}"
+            ) from error
 
     def delete(
         self, backup_name: str, purge_partial: bool

--- a/ch_backup/ch_backup.py
+++ b/ch_backup/ch_backup.py
@@ -8,6 +8,8 @@ from datetime import timedelta
 from enum import Enum
 from typing import Dict, List, Optional, Sequence, Set, Tuple
 
+import requests
+
 from ch_backup import logging
 from ch_backup.backup.deduplication import (
     DedupReferences,
@@ -381,7 +383,7 @@ class ClickhouseBackup:
 
         try:
             self._context.ch_ctl.check_zookeeper_available()
-        except ClickhouseError as error:
+        except (ClickhouseError, requests.exceptions.RequestException) as error:
             replicated_objects = []
             if replicated_databases:
                 replicated_objects.append(

--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -551,6 +551,16 @@ GET_ZOOKEEPER_ADMIN_UUID = strip_query(
 """
 )
 
+_CHECK_ZOOKEEPER_SQL = strip_query(
+    """
+    SELECT 1
+    FROM system.zookeeper
+    WHERE path = '/'
+    LIMIT 1
+    FORMAT Null
+"""
+)
+
 GET_PARTITIONS = strip_query(
     """
     SELECT DISTINCT partition_id
@@ -1175,6 +1185,12 @@ class ClickhouseCTL:
         """
         result = self._ch_client.query(GET_ZOOKEEPER_ADMIN_UUID).get("data", [])
         return {item["name"]: item["value"] for item in result}
+
+    def check_zookeeper_available(self) -> None:
+        """
+        Check that ClickHouse can access its configured ZooKeeper or Keeper.
+        """
+        self._ch_client.query(_CHECK_ZOOKEEPER_SQL, should_retry=False)
 
     @staticmethod
     def scan_frozen_parts(

--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -1190,7 +1190,7 @@ class ClickhouseCTL:
         """
         Check that ClickHouse can access its configured ZooKeeper or Keeper.
         """
-        self._ch_client.query(_CHECK_ZOOKEEPER_SQL, should_retry=False)
+        self._ch_client.query(_CHECK_ZOOKEEPER_SQL)
 
     @staticmethod
     def scan_frozen_parts(

--- a/tests/unit/test_ch_backup.py
+++ b/tests/unit/test_ch_backup.py
@@ -1,0 +1,99 @@
+from unittest.mock import Mock
+
+import pytest
+
+from ch_backup.backup.metadata import TableMetadata
+from ch_backup.backup.sources import BackupSources
+from ch_backup.ch_backup import ClickhouseBackup
+from ch_backup.clickhouse.client import ClickhouseError
+from ch_backup.clickhouse.models import Database
+from ch_backup.exceptions import ClickhouseBackupError
+
+
+def _backup_with_context(
+    database_engine: str = "Atomic", table_engine: str = "MergeTree"
+) -> tuple[ClickhouseBackup, Mock]:
+    context = Mock()
+    context.config = {"force_non_replicated": False}
+    context.backup_meta.get_database.return_value = Database(
+        "db", database_engine, None, None, None
+    )
+    context.backup_meta.get_tables.return_value = [
+        TableMetadata("db", "table", table_engine, None)
+    ]
+
+    backup = ClickhouseBackup.__new__(ClickhouseBackup)
+    backup.__dict__["_context"] = context
+    return backup, context
+
+
+def test_restore_checks_zookeeper_for_replicated_table() -> None:
+    backup, context = _backup_with_context(table_engine="ReplicatedMergeTree")
+
+    backup._check_zookeeper_for_restore(  # pylint: disable=protected-access
+        BackupSources(), ["db"], []
+    )
+
+    context.ch_ctl.check_zookeeper_available.assert_called_once_with()
+
+
+def test_restore_checks_zookeeper_for_replicated_database() -> None:
+    backup, context = _backup_with_context(database_engine="Replicated")
+
+    backup._check_zookeeper_for_restore(  # pylint: disable=protected-access
+        BackupSources(), ["db"], []
+    )
+
+    context.ch_ctl.check_zookeeper_available.assert_called_once_with()
+
+
+def test_restore_does_not_check_zookeeper_for_non_replicated_schema() -> None:
+    backup, context = _backup_with_context()
+
+    backup._check_zookeeper_for_restore(  # pylint: disable=protected-access
+        BackupSources(), ["db"], []
+    )
+
+    context.ch_ctl.check_zookeeper_available.assert_not_called()
+
+
+def test_restore_does_not_check_zookeeper_when_forcing_non_replicated() -> None:
+    backup, context = _backup_with_context(table_engine="ReplicatedMergeTree")
+    context.config["force_non_replicated"] = True
+
+    backup._check_zookeeper_for_restore(  # pylint: disable=protected-access
+        BackupSources(), ["db"], []
+    )
+
+    context.ch_ctl.check_zookeeper_available.assert_not_called()
+
+
+def test_restore_checks_only_selected_tables() -> None:
+    backup, context = _backup_with_context(table_engine="ReplicatedMergeTree")
+    selected_tables = [TableMetadata("db", "local_table", "MergeTree", None)]
+
+    backup._check_zookeeper_for_restore(  # pylint: disable=protected-access
+        BackupSources(), ["db"], selected_tables
+    )
+
+    context.ch_ctl.check_zookeeper_available.assert_not_called()
+
+
+def test_restore_reports_failed_zookeeper_check() -> None:
+    backup, context = _backup_with_context(
+        database_engine="Replicated", table_engine="ReplicatedMergeTree"
+    )
+    error = ClickhouseError("There is no Zookeeper configuration")
+    context.ch_ctl.check_zookeeper_available.side_effect = error
+
+    with pytest.raises(ClickhouseBackupError) as exc:
+        backup._check_zookeeper_for_restore(  # pylint: disable=protected-access
+            BackupSources(), ["db"], []
+        )
+
+    assert str(exc.value) == (
+        "Restore requires ZooKeeper or ClickHouse Keeper because we have replicated "
+        "databases: `db`, tables: `db`.`table`. Availability check through "
+        "ClickHouse failed: There is no Zookeeper configuration"
+    )
+    assert exc.value.__cause__ is error

--- a/tests/unit/test_ch_backup.py
+++ b/tests/unit/test_ch_backup.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+import requests
 
 from ch_backup.backup.metadata import TableMetadata
 from ch_backup.backup.sources import BackupSources
@@ -79,11 +80,18 @@ def test_restore_checks_only_selected_tables() -> None:
     context.ch_ctl.check_zookeeper_available.assert_not_called()
 
 
-def test_restore_reports_failed_zookeeper_check() -> None:
+@pytest.mark.parametrize(
+    "error",
+    [
+        ClickhouseError("There is no Zookeeper configuration"),
+        requests.exceptions.ConnectionError("ClickHouse is unreachable"),
+        requests.exceptions.ReadTimeout("ClickHouse query timed out"),
+    ],
+)
+def test_restore_reports_failed_zookeeper_check(error: Exception) -> None:
     backup, context = _backup_with_context(
         database_engine="Replicated", table_engine="ReplicatedMergeTree"
     )
-    error = ClickhouseError("There is no Zookeeper configuration")
     context.ch_ctl.check_zookeeper_available.side_effect = error
 
     with pytest.raises(ClickhouseBackupError) as exc:
@@ -94,6 +102,6 @@ def test_restore_reports_failed_zookeeper_check() -> None:
     assert str(exc.value) == (
         "Restore requires ZooKeeper or ClickHouse Keeper because we have replicated "
         "databases: `db`, tables: `db`.`table`. Availability check through "
-        "ClickHouse failed: There is no Zookeeper configuration"
+        f"ClickHouse failed: {error}"
     )
     assert exc.value.__cause__ is error


### PR DESCRIPTION
## Summary

- detect selected replicated databases and tables before restore starts
- probe ZooKeeper or ClickHouse Keeper through ClickHouse while returning no installation data
- fail early with names of replicated objects and original ClickHouse error
- skip check when restoring non-replicated schemas or forcing non-replicated engines

## Testing

- uv run pytest -q tests/unit (320 passed)
- Black, Ruff, MyPy, and Pylint checks passed

## Summary by Sourcery

Validate coordination-service availability before starting restores that require replicated database or table engines.

New Features:
- Check ZooKeeper or ClickHouse Keeper availability before restoring replicated databases or tables.
- Report the affected replicated objects and the underlying ClickHouse or connectivity error when the availability check fails.

Enhancements:
- Skip the availability check for non-replicated restores and when non-replicated engines are forced.

Tests:
- Add unit coverage for replicated-object detection, skip conditions, selected-table handling, and failure reporting.