### PR TITLE
Fix ClickHouse 26.8 configuration compatibility

### DIFF
--- a/ch_backup/clickhouse/disks.py
+++ b/ch_backup/clickhouse/disks.py
@@ -98,6 +98,7 @@ class ClickHouseTemporaryDisks:
                 for name, conf in self._disks.items()
                 if not conf or conf.get("type") != "cache"
             },
+            history_file=CH_DISK_HISTORY_FILE_PATH,
         )
         return self
 
@@ -123,15 +124,14 @@ class ClickHouseTemporaryDisks:
                 pass
         return True
 
-    def _render_disks_config(self, path, disks):
+    def _render_disks_config(self, path, disks, history_file=None):
+        config = {"storage_configuration": {"disks": disks}}
+        if history_file is not None:
+            config["history-file"] = history_file
+
         with open(path, "w", encoding="utf-8") as f:
             xmltodict.unparse(
-                {
-                    "clickhouse": {
-                        "storage_configuration": {"disks": disks},
-                        "history-file": CH_DISK_HISTORY_FILE_PATH,
-                    },
-                },
+                {"clickhouse": config},
                 f,
                 pretty=True,
             )

--- a/images/clickhouse/Dockerfile
+++ b/images/clickhouse/Dockerfile
@@ -102,6 +102,6 @@ RUN openssl genrsa -out /var/tmp/ssl/server.key 2048 && \
 
 COPY staging/images/{{ instance_name }}/entrypoint.py /entrypoint.py
 
-EXPOSE 8123 8443 9000 9440
+EXPOSE 8123 8443 9000
 
 CMD ["python3", "/entrypoint.py"]

--- a/images/clickhouse/config/clickhouse-server.xml
+++ b/images/clickhouse/config/clickhouse-server.xml
@@ -1,7 +1,6 @@
 <yandex>
     <listen_host>0.0.0.0</listen_host>
     <https_port>8443</https_port>
-    <tcp_ssl_port>9440</tcp_ssl_port>
 
     <openSSL>
         <server>

--- a/tests/integration/features/cloud_storage.feature
+++ b/tests/integration/features/cloud_storage.feature
@@ -251,9 +251,15 @@ Feature: Backup & Clean & Restore
     | 10           |
 
     @require_version_25.8
+    @require_version_less_than_26.8
     Examples:
     | object_count |
     | 11           |
+
+    @require_version_26.8
+    Examples:
+    | object_count |
+    | 12           |
 
   Scenario: Restore succeeds when target node has no storage_configuration section
     # Regression test for: ClickHouseTemporaryDisks.__enter__ raised KeyError when

--- a/tests/unit/test_disks.py
+++ b/tests/unit/test_disks.py
@@ -3,6 +3,7 @@ Unit tests disks module.
 """
 
 import unittest
+import unittest.mock
 from typing import List, Optional
 
 import xmltodict
@@ -60,7 +61,6 @@ write_result = ""
                     </object_storage>
                   </disks>
                 </storage_configuration>
-                <history-file>/tmp/.disks-file-history</history-file>
               </clickhouse>
               """,
         },
@@ -106,7 +106,6 @@ write_result = ""
                     </object_storage>
                   </disks>
                 </storage_configuration>
-                <history-file>/tmp/.disks-file-history</history-file>
               </clickhouse>
               """,
         },
@@ -149,7 +148,6 @@ write_result = ""
                     </object_storage_source>
                   </disks>
                 </storage_configuration>
-                <history-file>/tmp/.disks-file-history</history-file>
               </clickhouse>
               """,
         },
@@ -261,10 +259,20 @@ def test_enter_without_storage_configuration():
     """
     disk_manager = _make_temporary_disks(clickhouse_config_xml, cloud_storage_disks=[])
 
-    with unittest.mock.patch("builtins.open", new=unittest.mock.mock_open()):
+    # pylint: disable=global-statement
+    global write_result
+    write_result = ""
+    with unittest.mock.patch("builtins.open", new=unittest.mock.mock_open()) as m:
+        m().write = write_collector
         with disk_manager:
             # pylint: disable=protected-access
             assert disk_manager._disks == {}
+
+    actual_content = xmltodict.parse(write_result, disable_entities=False)
+    assert_equal(
+        actual_content["clickhouse"]["history-file"],
+        "/tmp/.disks-file-history",
+    )
 
 
 def test_create_temporary_disk_missing_disk_raises():


### PR DESCRIPTION
Upstream changes requiring this compatibility update:

- ClickHouse/ClickHouse#100332 introduced strict validation of unknown
  clickhouse-server configuration options. It exposed both the obsolete
  `tcp_ssl_port` setting during startup and the clickhouse-disks-only
  `history-file` option leaked into server configuration during
  `SYSTEM RELOAD CONFIG`.

- ClickHouse/ClickHouse#101275 enabled automatic statistics for new MergeTree
  columns. This adds a `statistics.packed` object on object-storage disks and
  changes the expected object count from 11 to 12 starting with ClickHouse 26.4.

For historical context, `tcp_ssl_port` was renamed to `tcp_port_secure` in
ClickHouse/ClickHouse#2065. The old setting remained unnoticed because earlier
server versions ignored unknown top-level configuration options.

## Summary by Sourcery

Remove the obsolete ClickHouse TCP SSL port and update disk configuration handling and coverage for current server versions.

Enhancements:
- Make disk history-file configuration optional while preserving it for temporary disk management.
- Align ClickHouse container configuration with removal of the obsolete TCP SSL port.

Build:
- Stop exposing the obsolete TCP SSL port from the ClickHouse image.

Tests:
- Update disk configuration tests and version-specific cloud storage scenarios for the revised ClickHouse behavior.