### PR TITLE
Fix flaky tests

### DIFF
--- a/ch_backup/storage/async_pipeline/pipelines.py
+++ b/ch_backup/storage/async_pipeline/pipelines.py
@@ -272,15 +272,7 @@ def run(pipeline: PypelnStage) -> None:
         itr = iter(pipeline)
         exhaust_iterator(itr)
     except ValueError as e:
-        # The library "stopit" (dependency of "pypeln") as of the version 1.1.2, incorrectly handle the case when
-        # timeout exception is sent to already terminated thread. It's incorrectly interpreted as an internal error.
-        # https://github.com/glenfant/stopit/blob/dda4bd181d1d29ab1fb22314dc9bde0e3c931abc/src/stopit/threadstop.py#L37
-        if "Invalid thread ID" in str(e):
-            logging.warning(
-                "Thread ID error due to incorrect handling of thread termination in stopit library, skipping",
-                exc_info=True,
-            )
-        else:
+        if not _ignore_invalid_thread_id_error(e):
             raise
 
 
@@ -291,7 +283,11 @@ def run_and_return_first(pipeline: PypelnStage) -> Any:
     itr = iter(pipeline)
 
     result = next(itr)  # Fetch and save first item
-    exhaust_iterator(itr)
+    try:
+        exhaust_iterator(itr)
+    except ValueError as e:
+        if not _ignore_invalid_thread_id_error(e):
+            raise
 
     return result
 
@@ -303,13 +299,32 @@ def run_and_collect_all(pipeline: PypelnStage) -> List[Any]:
     itr = iter(pipeline)
     results: list = []
 
-    for item in itr:
-        if isinstance(item, Iterator):
-            results.extend(item)
-        else:
-            results.append(item)
+    try:
+        for item in itr:
+            if isinstance(item, Iterator):
+                results.extend(item)
+            else:
+                results.append(item)
+    except ValueError as e:
+        if not _ignore_invalid_thread_id_error(e):
+            raise
 
     return results
+
+
+def _ignore_invalid_thread_id_error(error: ValueError) -> bool:
+    # The library "stopit" (dependency of "pypeln") as of version 1.1.2
+    # incorrectly handles a timeout exception sent to an already terminated
+    # thread as an internal error.
+    # https://github.com/glenfant/stopit/blob/dda4bd181d1d29ab1fb22314dc9bde0e3c931abc/src/stopit/threadstop.py#L37
+    if "Invalid thread ID" not in str(error):
+        return False
+
+    logging.warning(
+        "Thread ID error due to incorrect handling of thread termination in stopit library, skipping",
+        exc_info=True,
+    )
+    return True
 
 
 def _calc_encrypted_size(config: dict, data_size: int) -> int:

--- a/images/minio/Dockerfile
+++ b/images/minio/Dockerfile
@@ -7,9 +7,16 @@ COPY --from=0 /usr/bin/mc /usr/bin/mc
 ENV MINIO_ACCESS_KEY {{ conf.s3.access_key_id }}
 ENV MINIO_SECRET_KEY {{ conf.s3.access_secret_key }}
 
+# ClickHouse checks that these buckets exist during startup.
+RUN mkdir -p \
+    /export/{{ conf.s3.bucket }} \
+    /export/{{ conf.s3.cloud_storage_bucket }}-01 \
+    /export/{{ conf.s3.cloud_storage_bucket }}-02
+
 ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
 
-HEALTHCHECK --interval=500ms --timeout=1s --retries=60 CMD /usr/bin/healthcheck.sh
+HEALTHCHECK --interval=500ms --timeout=1s --retries=60 \
+    CMD curl --fail --silent http://localhost:9000/minio/health/ready
 
 EXPOSE 9000 9001
 

--- a/images/minio/Dockerfile
+++ b/images/minio/Dockerfile
@@ -9,8 +9,8 @@ ENV MINIO_SECRET_KEY {{ conf.s3.access_secret_key }}
 
 ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
 
-HEALTHCHECK --interval=30s --timeout=5s CMD /usr/bin/healthcheck.sh
+HEALTHCHECK --interval=500ms --timeout=1s --retries=60 CMD /usr/bin/healthcheck.sh
 
-EXPOSE 9000
+EXPOSE 9000 9001
 
-CMD ["server", "/export"]
+CMD ["server", "/export", "--console-address", ":9001"]

--- a/tests/integration/configuration.py
+++ b/tests/integration/configuration.py
@@ -73,7 +73,7 @@ def create():
                 },
                 "docker_instances": 2,
                 "depends_on": {
-                    "minio": "service_started",
+                    "minio": "service_healthy",
                     "proxy": "service_started",
                     "proxy-api": "service_started",
                     "zookeeper": "service_healthy",

--- a/tests/integration/modules/logs.py
+++ b/tests/integration/modules/logs.py
@@ -37,6 +37,11 @@ def save_logs(context: ContextT) -> None:
 def _save_container_logs(container: Container, logs_dir: str) -> None:
     base = os.path.join(logs_dir, container.name)
     os.makedirs(base, exist_ok=True)
+
+    container.reload()
+    with open(os.path.join(base, "state.json"), "w", encoding="utf-8") as out:
+        json.dump(container.attrs["State"], out, default=repr, indent=4)
+
     with open(os.path.join(base, "docker.log"), "wb") as out:
         out.write(container.logs(stdout=True, stderr=True, timestamps=True))
 


### PR DESCRIPTION
Fixes CI flaky errors

1.
```
    When we restore clickhouse backup #0 to clickhouse02                             # tests/integration/steps/ch_backup_steps.py:114
      ASSERT FAILED: execution failed with code 1, out: "Traceback (most recent call last):
        File "/usr/local/lib/python3.14/site-packages/ch_backup/backup/layout.py", line 410, in _load_metadata
          data = self._storage_loader.download_data(path, encryption=encryption)
        File "/usr/local/lib/python3.14/site-packages/ch_backup/storage/loader.py", line 164, in download_data
          data = self._ploader.download_data(
              remote_path, is_async=is_async, encryption=encryption
          )
        File "/usr/local/lib/python3.14/site-packages/ch_backup/storage/async_pipeline/pipeline_executor.py", line 191, in download_data
          return self._exec_pipeline(job_id, pipeline, is_async)
                 ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/lib/python3.14/site-packages/ch_backup/storage/async_pipeline/pipeline_executor.py", line 301, in _exec_pipeline
          result = pipeline()
        File "/usr/local/lib/python3.14/site-packages/ch_backup/storage/async_pipeline/pipelines.py", line 187, in download_data_pipeline
          return run_and_return_first(builder.pipeline())
        File "/usr/local/lib/python3.14/site-packages/ch_backup/storage/async_pipeline/pipelines.py", line 290, in run_and_return_first
          exhaust_iterator(itr)
          ~~~~~~~~~~~~~~~~^^^^^
        File "/usr/local/lib/python3.14/site-packages/ch_backup/util.py", line 419, in exhaust_iterator
          collections.deque(iterator, maxlen=0)
          ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/lib/python3.14/site-packages/pypeln/thread/stage.py", line 81, in to_iterable
          with supervisor:
               ^^^^^^^^^^
        File "/usr/local/lib/python3.14/site-packages/pypeln/thread/supervisor.py", line 46, in __exit__
          worker.stop()
          ~~~~~~~~~~~^^
        File "/usr/local/lib/python3.14/site-packages/pypeln/thread/worker.py", line 140, in stop
          stopit.async_raise(
          ~~~~~~~~~~~~~~~~~~^
              self.process.ident,
              ^^^^^^^^^^^^^^^^^^^
              pypeln_utils.StopThreadException,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          )
          ^
        File "/usr/local/lib/python3.14/site-packages/stopit/threadstop.py", line 31, in async_raise
          raise ValueError("Invalid thread ID {}".format(target_tid))
      ValueError: Invalid thread ID 140697659233984
      
      The above exception was the direct cause of the following exception:
      
      Traceback (most recent call last):
        File "/usr/local/bin/ch-backup", line 6, in <module>
          sys.exit(main())
                   ~~~~^^
        File "/usr/local/lib/python3.14/site-packages/click/core.py", line 1161, in __call__
          return self.main(*args, **kwargs)
                 ~~~~~~~~~^^^^^^^^^^^^^^^^^
        File "/usr/local/lib/python3.14/site-packages/click/core.py", line 1082, in main
          rv = self.invoke(ctx)
        File "/usr/local/lib/python3.14/site-packages/click/core.py", line 1697, in invoke
          return _process_result(sub_ctx.command.invoke(sub_ctx))
                                 ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
        File "/usr/local/lib/python3.14/site-packages/click/core.py", line 1443, in invoke
          return ctx.invoke(self.callback, **ctx.params)
                 ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/lib/python3.14/site-packages/click/core.py", line 788, in invoke
          return __callback(*args, **kwargs)
        File "/usr/local/lib/python3.14/site-packages/click/decorators.py", line 33, in new_func
          return f(get_current_context(), *args, **kwargs)
        File "/usr/local/lib/python3.14/site-packages/ch_backup/profile.py", line 45, in __call__
          result = self.func(*args, **kwargs)
        File "/usr/local/lib/python3.14/site-packages/ch_backup/cli.py", line 193, in wrapper
          result = ctx.invoke(f, ctx, ctx.obj["backup"], *args, **kwargs)
        File "/usr/local/lib/python3.14/site-packages/click/core.py", line 788, in invoke
          return __callback(*args, **kwargs)
        File "/usr/local/lib/python3.14/site-packages/ch_backup/cli.py", line 232, in list_command
          backups = ch_backup.list(state)
        File "/usr/local/lib/python3.14/site-packages/ch_backup/ch_backup.py", line 104, in list
          for backup in self._context.backup_layout.get_backups(use_light_meta=True):
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/lib/python3.14/site-packages/ch_backup/backup/layout.py", line 463, in get_backups
          backup = self.get_backup(name, use_light_meta)
        File "/usr/local/lib/python3.14/site-packages/ch_backup/backup/layout.py", line 439, in get_backup
          return self._load_metadata(path, not use_light_meta)
                 ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/lib/python3.14/site-packages/ch_backup/backup/layout.py", line 419, in _load_metadata
          raise StorageError("Failed to download backup metadata") from e
      ch_backup.exceptions.StorageError: Failed to download backup metadata

    Then we got same clickhouse data at clickhouse01 clickhouse02                    # None
    When we create clickhouse01 clickhouse backup                                    # None
    Then we got the following backups on clickhouse01                                # None
      | num | state   | data_count | link_count |
      | 0   | created | 0          | 1          |
      | 1   | created | 0          | 1          |
      | 2   | created | 1          | 0          |
    When we restore clickhouse backup #0 to clickhouse02                             # None
    Then we got same clickhouse data at clickhouse01 clickhouse02                    # None
----
CAPTURED LOG: before_scenario
LOG_INFO:root: initiating stop stage tests.integration.modules.compose.shutdown_containers
LOG_INFO:root: initiating create stage tests.integration.modules.docker.create_network
LOG_INFO:root: initiating start stage tests.integration.modules.compose.startup_containers
---- CAPTURED_SCENARIO_OUTPUT_END ----
```

2.
```
    And a working clickhouse on clickhouse01                                                    # tests/integration/steps/clickhouse.py:17
      Traceback (most recent call last):
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.11/site-packages/urllib3/connectionpool.py", line 787, in urlopen
          response = self._make_request(
                     ^^^^^^^^^^^^^^^^^^^
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.11/site-packages/urllib3/connectionpool.py", line 534, in _make_request
          response = conn.getresponse()
                     ^^^^^^^^^^^^^^^^^^
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.11/site-packages/urllib3/connection.py", line 516, in getresponse
          httplib_response = super().getresponse()
                             ^^^^^^^^^^^^^^^^^^^^^
        File "/home/runner/work/_temp/uv-python-dir/cpython-3.11.16-linux-x86_64-gnu/lib/python3.11/http/client.py", line 1443, in getresponse
          response.begin()
        File "/home/runner/work/_temp/uv-python-dir/cpython-3.11.16-linux-x86_64-gnu/lib/python3.11/http/client.py", line 337, in begin
          version, status, reason = self._read_status()
                                    ^^^^^^^^^^^^^^^^^^^
        File "/home/runner/work/_temp/uv-python-dir/cpython-3.11.16-linux-x86_64-gnu/lib/python3.11/http/client.py", line 298, in _read_status
          line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/runner/work/_temp/uv-python-dir/cpython-3.11.16-linux-x86_64-gnu/lib/python3.11/socket.py", line 718, in readinto
          return self._sock.recv_into(b)
                 ^^^^^^^^^^^^^^^^^^^^^^^
      ConnectionResetError: [Errno 104] Connection reset by peer
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.11/site-packages/requests/adapters.py", line 667, in send
          resp = conn.urlopen(
                 ^^^^^^^^^^^^^
```
3.
```
    And a working s3                                              # tests/integration/steps/s3.py:13
      Traceback (most recent call last):
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.10/site-packages/docker/api/client.py", line 275, in _raise_for_status
          response.raise_for_status()
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.10/site-packages/requests/models.py", line 1024, in raise_for_status
          raise HTTPError(http_error_msg, response=self)
      requests.exceptions.HTTPError: 409 Client Error: Conflict for url: http+docker://localhost/v1.48/containers/30a743f806cf7d2e9cc228d1a78767908d82a2d593a8b198908f94dee7543163/exec
      
      The above exception was the direct cause of the following exception:
      
      Traceback (most recent call last):
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.10/site-packages/behave/model.py", line 1991, in run
          match.run(runner.context)
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.10/site-packages/behave/matchers.py", line 105, in run
          self.func(context, *args, **kwargs)
        File "tests/integration/steps/s3.py", line 19, in step_wait_for_s3_alive
          configure_s3_credentials(context)
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.10/site-packages/tenacity/__init__.py", line 338, in wrapped_f
          return copy(f, *args, **kw)
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.10/site-packages/tenacity/__init__.py", line 477, in __call__
          do = self.iter(retry_state=retry_state)
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.10/site-packages/tenacity/__init__.py", line 378, in iter
          result = action(retry_state)
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.10/site-packages/tenacity/__init__.py", line 400, in <lambda>
          self._add_action_func(lambda rs: rs.outcome.result())
        File "/usr/lib/python3.10/concurrent/futures/_base.py", line 451, in result
          return self.__get_result()
        File "/usr/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
          raise self._exception
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.10/site-packages/tenacity/__init__.py", line 480, in __call__
          result = fn(*args, **kwargs)
        File "/home/runner/work/ch-backup/ch-backup/tests/integration/modules/minio.py", line 59, in configure_s3_credentials
          _mc_execute(
        File "/home/runner/work/ch-backup/ch-backup/tests/integration/modules/minio.py", line 98, in _mc_execute
          output = _container(context).exec_run(f"mc --json {command}").output.decode()
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.10/site-packages/docker/models/containers.py", line 208, in exec_run
          resp = self.client.api.exec_create(
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.10/site-packages/docker/utils/decorators.py", line 19, in wrapped
          return f(self, resource_id, *args, **kwargs)
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.10/site-packages/docker/api/exec_api.py", line 78, in exec_create
          return self._result(res, True)
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.10/site-packages/docker/api/client.py", line 281, in _result
          self._raise_for_status(response)
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.10/site-packages/docker/api/client.py", line 277, in _raise_for_status
          raise create_api_error_from_http_exception(e) from e
        File "/home/runner/work/ch-backup/ch-backup/.venv/lib/python3.10/site-packages/docker/errors.py", line 39, in create_api_error_from_http_exception
          raise cls(e, response=response, explanation=explanation) from e
      docker.errors.APIError: 409 Client Error for http+docker://localhost/v1.48/containers/30a743f806cf7d2e9cc228d1a78767908d82a2d593a8b198908f94dee7543163/exec: Conflict ("container 30a743f806cf7d2e9cc228d1a78767908d82a2d593a8b198908f94dee7543163 is not running")
```
## Summary by Sourcery

Prevent transient thread-termination errors from breaking backup operations and improve the reliability and diagnostics of integration environments.

Bug Fixes:
- Ignore spurious invalid thread ID errors across all asynchronous pipeline consumption paths so backup metadata operations are not incorrectly reported as failed.

Enhancements:
- Improve MinIO readiness handling and startup compatibility by provisioning required buckets, exposing the console, and waiting for the health check before dependent integration services start.
- Capture Docker container state alongside logs to improve integration-test diagnostics.