### PR TITLE
Support backup on cluster with workload config in xml

### DIFF
--- a/ch_backup/logic/workload_entities.py
+++ b/ch_backup/logic/workload_entities.py
@@ -122,14 +122,12 @@ class WorkloadEntitiesBackup(BackupManager):
             tmp_path,
             context.backup_meta.name,
         ) as backup_tmp_path:
-            for entity_name, _ in workload_entities:
-                context.backup_meta.add_workload_entity(entity_name)
-
             we_config = WorkloadEntitiesStorageConfig.from_ch_config(
                 context.ch_ctl_conf, context.ch_config
             )
             if we_config.is_local_storage():
-                copy_directory_content(we_config.storage_path, backup_tmp_path)
+                if os.path.exists(we_config.storage_path):
+                    copy_directory_content(we_config.storage_path, backup_tmp_path)
             elif we_config.is_storage_zookeeper():
                 self._write_entities_from_zookeeper_node(
                     context.zk_ctl,
@@ -146,7 +144,17 @@ class WorkloadEntitiesBackup(BackupManager):
                         name=entity_name, type=entity_type, create_statement=""
                     ).filename_on_disk(),
                 )
+                if not os.path.isfile(local_path):
+                    logging.info(
+                        "Skipping {} workload entity {} because no matching SQL "
+                        "definition was found in {} storage",
+                        entity_type.value,
+                        entity_name,
+                        we_config.storage_type.value,
+                    )
+                    continue
 
+                context.backup_meta.add_workload_entity(entity_name)
                 context.backup_layout.upload_workload_entity_ddl_from_file(
                     local_path,
                     context.backup_meta.name,

--- a/images/clickhouse/config/workload_entity_storage/resources_and_workloads.xml
+++ b/images/clickhouse/config/workload_entity_storage/resources_and_workloads.xml
@@ -1,0 +1,7 @@
+<yandex>
+    <resources_and_workloads>
+        CREATE RESOURCE xml_s3_read (READ DISK s3);
+        CREATE WORKLOAD xml_all;
+        CREATE WORKLOAD xml_production IN xml_all SETTINGS weight = 3;
+    </resources_and_workloads>
+</yandex>

--- a/tests/integration/features/workload_entities.feature
+++ b/tests/integration/features/workload_entities.feature
@@ -73,3 +73,30 @@ Feature: Workload entities (WORKLOADs and RESOURCEs) support
     """
     CREATE RESOURCE s3_write (WRITE DISK s3)
     """
+
+  @require_version_25.10
+  Scenario: Skip configuration-defined workload entities during backup
+    Given we replace config file no_storage.xml in favor of workload_entity_storage/resources_and_workloads.xml on clickhouse01 with restart
+    When we execute query on clickhouse01
+    """
+    SELECT count() FROM system.workloads WHERE name IN ('xml_all', 'xml_production');
+    """
+    Then we get response
+    """
+    2
+    """
+    When we execute query on clickhouse01
+    """
+    SELECT count() FROM system.resources WHERE name = 'xml_s3_read';
+    """
+    Then we get response
+    """
+    1
+    """
+    When we create clickhouse01 clickhouse backup
+    Then clickhouse01 backup #0 contains no workload entities
+    When we create clickhouse01 clickhouse backup
+    """
+    schema_only: true
+    """
+    Then clickhouse01 backup #1 contains no workload entities

--- a/tests/integration/steps/ch_backup_steps.py
+++ b/tests/integration/steps/ch_backup_steps.py
@@ -167,6 +167,12 @@ def step_backup_metadata_absent(context, node, backup_id):
     assert_that(backup.meta, not has_entries(expected_meta))
 
 
+@then("{node:w} backup #{backup_id:d} contains no workload entities")
+def step_backup_contains_no_workload_entities(context, node, backup_id):
+    backup = BackupManager(context, node).get_backup(backup_id)
+    assert_that(backup.metadata["workload_entities"], equal_to([]))
+
+
 @then("we got no backups on {node:w}")
 def step_no_backups(context, node):
     ch_backup = BackupManager(context, node)

--- a/tests/unit/test_workload_entities.py
+++ b/tests/unit/test_workload_entities.py
@@ -1,11 +1,131 @@
-"""
-Unit tests for WorkloadEntity.from_create_statement
-"""
+"""Unit tests for workload entity backup logic."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Sequence, Tuple, cast
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from ch_backup.backup_context import BackupContext
 from ch_backup.clickhouse.models import WorkloadEntityType
-from ch_backup.logic.workload_entities import WorkloadEntity
+from ch_backup.logic import workload_entities
+from ch_backup.logic.workload_entities import WorkloadEntitiesBackup, WorkloadEntity
+
+
+def _backup_context(
+    tmp_path: Path,
+    storage_path: str,
+    entities: Sequence[Tuple[str, WorkloadEntityType]],
+    *,
+    zookeeper: bool = False,
+) -> SimpleNamespace:
+    ch_ctl = MagicMock()
+    ch_ctl.ch_version_ge.return_value = True
+    ch_ctl.get_workload_entities_query.return_value = entities
+
+    backup_meta = MagicMock()
+    backup_meta.name = "backup"
+
+    ch_config = {}
+    if zookeeper:
+        ch_config["workload_zookeeper_path"] = storage_path
+
+    zk_client = MagicMock()
+    zk_client.__enter__.return_value = zk_client
+    zk_ctl = SimpleNamespace(zk_client=zk_client, zk_root_path="/root")
+
+    return SimpleNamespace(
+        ch_ctl=ch_ctl,
+        ch_ctl_conf={
+            "user": "clickhouse",
+            "group": "clickhouse",
+            "tmp_path": str(tmp_path),
+            "workload_path": storage_path,
+        },
+        ch_config=SimpleNamespace(config=ch_config),
+        backup_meta=backup_meta,
+        backup_layout=MagicMock(),
+        zk_ctl=zk_ctl,
+    )
+
+
+def _backup(context: SimpleNamespace) -> None:
+    with (
+        patch.object(workload_entities, "ensure_owned_directory"),
+        patch.object(workload_entities, "chown_dir_contents"),
+    ):
+        WorkloadEntitiesBackup().backup(cast(BackupContext, context))
+
+
+def test_backup_skips_visible_xml_entities_without_local_storage(
+    tmp_path: Path,
+) -> None:
+    context = _backup_context(
+        tmp_path,
+        str(tmp_path / "missing-workload-storage"),
+        [("xml_workload", WorkloadEntityType.WORKLOAD)],
+    )
+
+    with patch.object(workload_entities.logging, "info") as log_info:
+        _backup(context)
+
+    context.backup_meta.add_workload_entity.assert_not_called()
+    context.backup_layout.upload_workload_entity_ddl_from_file.assert_not_called()
+    log_info.assert_any_call(
+        "Skipping {} workload entity {} because no matching SQL definition was found in {} storage",
+        "workload",
+        "xml_workload",
+        "local",
+    )
+
+
+def test_backup_includes_only_entities_with_stored_sql_files(tmp_path: Path) -> None:
+    storage_path = tmp_path / "workload"
+    storage_path.mkdir()
+    sql_entity = WorkloadEntity(
+        name="sql workload",
+        type=WorkloadEntityType.WORKLOAD,
+        create_statement="CREATE WORKLOAD `sql workload`",
+    )
+    (storage_path / sql_entity.filename_on_disk()).write_text(
+        sql_entity.create_statement, encoding="utf-8"
+    )
+    context = _backup_context(
+        tmp_path,
+        str(storage_path),
+        [
+            ("xml_resource", WorkloadEntityType.RESOURCE),
+            (sql_entity.name, sql_entity.type),
+        ],
+    )
+
+    _backup(context)
+
+    context.backup_meta.add_workload_entity.assert_called_once_with(sql_entity.name)
+    upload_call = (
+        context.backup_layout.upload_workload_entity_ddl_from_file.call_args.args
+    )
+    assert Path(upload_call[0]).name == sql_entity.filename_on_disk()
+    assert upload_call[1:] == ("backup", sql_entity.name)
+
+
+def test_backup_skips_entities_when_zookeeper_data_is_missing(tmp_path: Path) -> None:
+    context = _backup_context(
+        tmp_path,
+        "/clickhouse/workload/definitions.sql",
+        [("sql_workload", WorkloadEntityType.WORKLOAD)],
+        zookeeper=True,
+    )
+    context.zk_ctl.zk_client.exists.return_value = False
+
+    _backup(context)
+
+    context.zk_ctl.zk_client.exists.assert_called_once_with(
+        "/root/clickhouse/workload/definitions.sql"
+    )
+    context.backup_meta.add_workload_entity.assert_not_called()
+    context.backup_layout.upload_workload_entity_ddl_from_file.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_workload_entities.py
+++ b/tests/unit/test_workload_entities.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Sequence, Tuple, cast
+from typing import Sequence, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,7 +16,7 @@ from ch_backup.logic.workload_entities import WorkloadEntitiesBackup, WorkloadEn
 def _backup_context(
     tmp_path: Path,
     storage_path: str,
-    entities: Sequence[Tuple[str, WorkloadEntityType]],
+    entities: Sequence[tuple[str, WorkloadEntityType]],
     *,
     zookeeper: bool = False,
 ) -> SimpleNamespace:


### PR DESCRIPTION
Fix
```
  File "/opt/yandex/ch-backup/lib/python3.10/site-packages/ch_backup/cli.py", line 445, in backup_command
    name, msg = ch_backup.backup(
> File "/opt/yandex/ch-backup/lib/python3.10/site-packages/ch_backup/ch_backup.py", line 195, in backup
    self._we_backup_manager.backup(self._context)
  File "/opt/yandex/ch-backup/lib/python3.10/site-packages/ch_backup/logic/workload_entities.py", line 132, in backup
    copy_directory_content(we_config.storage_path, backup_tmp_path)
  File "/opt/yandex/ch-backup/lib/python3.10/site-packages/ch_backup/util.py", line 498, in copy_directory_content
    for subpath in os.listdir(from_path_dir):
FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/clickhouse/workload'
```

## Summary by Sourcery

Make workload entity backups resilient to configuration-defined entities that are not persisted in backup storage.

Bug Fixes:
- Prevent backups from failing when workload entity storage is absent or when configuration-defined entities have no corresponding stored SQL definitions.

Enhancements:
- Record only workload entities whose SQL definitions are available for backup, while skipping XML- and otherwise unavailable entities.

Tests:
- Add unit and integration coverage for skipping workload entities defined in XML, missing local storage, and missing ZooKeeper data.