### PR TITLE
Validate settings config type (must be a mapping)

### DIFF
--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -25,7 +25,7 @@ from ch_backup.clickhouse.models import (
     Table,
     WorkloadEntityType,
 )
-from ch_backup.exceptions import ClickhouseBackupError
+from ch_backup.exceptions import ClickhouseBackupError, ConfigurationError
 from ch_backup.storage.async_pipeline.base_pipeline.exec_pool import ThreadExecPool
 from ch_backup.util import (
     chown_dir_contents,
@@ -614,6 +614,10 @@ class ClickhouseCTL:
         self._ch_version = self._ch_client.query(GET_VERSION_SQL)
         self._disks = self.get_disks()
         settings = self._ch_ctl_config.get("settings")
+        if settings is not None and not isinstance(settings, dict):
+            raise ConfigurationError(
+                f'"settings" must be a mapping, got {type(settings).__name__}'
+            )
         if settings is None:
             settings = {
                 "allow_deprecated_database_ordinary": 1,

--- a/ch_backup/clickhouse/control.py
+++ b/ch_backup/clickhouse/control.py
@@ -610,14 +610,14 @@ class ClickhouseCTL:
         self._unfreeze_timeout = self._ch_ctl_config["unfreeze_timeout"]
         self._restore_replica_timeout = self._ch_ctl_config["restore_replica_timeout"]
         self._drop_replica_timeout = self._ch_ctl_config["drop_replica_timeout"]
-        self._ch_client = ClickhouseClient(self._ch_ctl_config)
-        self._ch_version = self._ch_client.query(GET_VERSION_SQL)
-        self._disks = self.get_disks()
         settings = self._ch_ctl_config.get("settings")
         if settings is not None and not isinstance(settings, dict):
             raise ConfigurationError(
                 f'"settings" must be a mapping, got {type(settings).__name__}'
             )
+        self._ch_client = ClickhouseClient(self._ch_ctl_config)
+        self._ch_version = self._ch_client.query(GET_VERSION_SQL)
+        self._disks = self.get_disks()
         if settings is None:
             settings = {
                 "allow_deprecated_database_ordinary": 1,

--- a/tests/unit/test_settings_validation.py
+++ b/tests/unit/test_settings_validation.py
@@ -20,13 +20,15 @@ def _ctl_config(settings=None):
     return config
 
 
-@mock.patch("ch_backup.clickhouse.control.ClickhouseClient")
-@mock.patch.object(ClickhouseCTL, "get_disks", return_value={})
-def _new_ctl(settings, _get_disks_mock, client_cls_mock):
-    client = client_cls_mock.return_value
-    client.query.return_value = "25.10.2.65"
-    client.settings = mock.Mock()
-    ClickhouseCTL(_ctl_config(settings=settings), {}, {})
+def _new_ctl(settings):
+    with (
+        mock.patch("ch_backup.clickhouse.control.ClickhouseClient") as client_cls_mock,
+        mock.patch.object(ClickhouseCTL, "get_disks", return_value={}),
+    ):
+        client = client_cls_mock.return_value
+        client.query.return_value = "25.10.2.65"
+        client.settings = mock.Mock()
+        ClickhouseCTL(_ctl_config(settings=settings), {}, {})
 
 
 @pytest.mark.parametrize(
@@ -44,9 +46,7 @@ def test_settings_non_mapping_raises_configuration_error(settings):
 
 @mock.patch("ch_backup.clickhouse.control.ClickhouseClient")
 @mock.patch.object(ClickhouseCTL, "get_disks", return_value={})
-def test_settings_validated_before_client_creation(
-    _get_disks_mock, client_cls_mock
-):
+def test_settings_validated_before_client_creation(_get_disks_mock, client_cls_mock):
     """Invalid settings must be rejected before any ClickHouse client is built.
 
     The client constructor connects/initializes, so a misconfigured `settings`

--- a/tests/unit/test_settings_validation.py
+++ b/tests/unit/test_settings_validation.py
@@ -1,0 +1,42 @@
+from unittest import mock
+
+import pytest
+
+from ch_backup.clickhouse.control import ClickhouseCTL
+from ch_backup.exceptions import ConfigurationError
+
+
+def _ctl_config(settings=None):
+    config = {
+        "data_path": "/tmp",
+        "timeout": 10,
+        "freeze_timeout": 10,
+        "unfreeze_timeout": 10,
+        "restore_replica_timeout": 10,
+        "drop_replica_timeout": 10,
+    }
+    if settings is not None:
+        config["settings"] = settings
+    return config
+
+
+@mock.patch("ch_backup.clickhouse.control.ClickhouseClient")
+@mock.patch.object(ClickhouseCTL, "get_disks", return_value={})
+def _new_ctl(settings, _get_disks_mock, client_cls_mock):
+    client = client_cls_mock.return_value
+    client.query.return_value = "25.10.2.65"
+    client.settings = mock.Mock()
+    ClickhouseCTL(_ctl_config(settings=settings), {}, {})
+
+
+@pytest.mark.parametrize(
+    "settings",
+    [
+        ["a", "b"],
+        "not-a-dict",
+        42,
+    ],
+)
+def test_settings_non_mapping_raises_configuration_error(settings):
+    with pytest.raises(ConfigurationError):
+        _new_ctl(settings)

--- a/tests/unit/test_settings_validation.py
+++ b/tests/unit/test_settings_validation.py
@@ -40,3 +40,18 @@ def _new_ctl(settings, _get_disks_mock, client_cls_mock):
 def test_settings_non_mapping_raises_configuration_error(settings):
     with pytest.raises(ConfigurationError):
         _new_ctl(settings)
+
+
+@mock.patch("ch_backup.clickhouse.control.ClickhouseClient")
+@mock.patch.object(ClickhouseCTL, "get_disks", return_value={})
+def test_settings_validated_before_client_creation(
+    _get_disks_mock, client_cls_mock
+):
+    """Invalid settings must be rejected before any ClickHouse client is built.
+
+    The client constructor connects/initializes, so a misconfigured `settings`
+    should surface a ConfigurationError even when ClickHouse is unreachable.
+    """
+    with pytest.raises(ConfigurationError):
+        ClickhouseCTL(_ctl_config(settings="not-a-dict"), {}, {})
+    client_cls_mock.assert_not_called()


### PR DESCRIPTION
## Summary

`ch-backup` assumes the `settings` configuration value is a dict and passes it directly to `dict.update()` (in `ClickhouseCTL.__init__`). If a user provides a non-dict value (list, string, int) in their config file, the code fails deep in the call stack with an unclear error.

## Change

- Validate `settings` right after it is read from the config. If it is present and not a `dict`, raise `ConfigurationError` with a clear message: `"settings" must be a mapping, got <type>`.
- `None` (unset) keeps the existing default-settings behavior unchanged.

## Test

- `tests/unit/test_settings_validation.py`: parametrized over `list`, `str`, `int` inputs, asserting `ConfigurationError` is raised.

Closes #249

## Summary by Sourcery

Validate the settings configuration type early and provide a clear error for invalid values.

Bug Fixes:
- Reject non-mapping `settings` configuration values with a clear `ConfigurationError` instead of allowing an unclear downstream failure.

Enhancements:
- Validate `settings` before creating the ClickHouse client while preserving default behavior when it is unset.

Tests:
- Add coverage for invalid list, string, and integer settings values and for validation before client creation.