### PR TITLE
Fix flaky restore tests

### DIFF
--- a/ch_backup/storage/async_pipeline/pipelines.py
+++ b/ch_backup/storage/async_pipeline/pipelines.py
@@ -277,12 +277,14 @@ def run_and_return_first(pipeline: PypelnStage) -> Any:
     Run pipeline until it is complete and return first its result.
     """
     itr = iter(pipeline)
+    result_fetched = False
 
-    result = next(itr)  # Fetch and save first item
     try:
+        result = next(itr)  # Fetch and save first item
+        result_fetched = True
         exhaust_iterator(itr)
     except ValueError as e:
-        if not _ignore_invalid_thread_id_error(e):
+        if not _ignore_invalid_thread_id_error(e) or not result_fetched:
             raise
 
     return result
@@ -315,6 +317,10 @@ def _ignore_invalid_thread_id_error(error: ValueError) -> bool:
     # https://github.com/glenfant/stopit/blob/dda4bd181d1d29ab1fb22314dc9bde0e3c931abc/src/stopit/threadstop.py#L37
     if "Invalid thread ID" not in str(error):
         return False
+
+    # stopit may fail during cleanup and mask the original pipeline exception.
+    if error.__context__ is not None:
+        raise error.__context__ from None
 
     logging.warning(
         "Thread ID error due to incorrect handling of thread termination in stopit library, skipping",

--- a/tests/integration/features/backup_replicated.feature
+++ b/tests/integration/features/backup_replicated.feature
@@ -918,8 +918,6 @@ Feature: Backup replicated merge tree table
     ENGINE = ReplicatedMergeTree('/clickhouse/tables/shard1/test_db.table_01', 'r1')
     ORDER BY id;
 
-    INSERT INTO test_db.table_01 SELECT number FROM system.numbers LIMIT 10;
-
     CREATE TABLE test_db.table_02 (id UInt32)
     ENGINE = ReplicatedMergeTree('/clickhouse/tables/shard1/test_db.table_01', 'r2')
     ORDER BY id;
@@ -931,7 +929,7 @@ Feature: Backup replicated merge tree table
     """
     Then we got the following backups on clickhouse01
       | num | state   | data_count | link_count |
-      | 0   | created | 1          | 0          |
+      | 0   | created | 0          | 0          |
     When we dirty remove clickhouse data at clickhouse01
     And we restore clickhouse backup #0 to clickhouse01
     """

--- a/tests/unit/test_pipelines.py
+++ b/tests/unit/test_pipelines.py
@@ -1,0 +1,50 @@
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import pytest
+
+from ch_backup.storage.async_pipeline.pipelines import (
+    run,
+    run_and_collect_all,
+    run_and_return_first,
+)
+
+
+def _pipeline_with_masked_error() -> Iterator[str]:
+    yield from ()
+    try:
+        raise RuntimeError("pipeline failed")
+    except RuntimeError:
+        raise ValueError("Invalid thread ID 123")
+
+
+def _pipeline_with_cleanup_error() -> Iterator[str]:
+    yield "result"
+    raise ValueError("Invalid thread ID 123")
+
+
+@pytest.mark.parametrize("runner", [run, run_and_return_first, run_and_collect_all])
+def test_run_restores_pipeline_error(runner: Callable[[Any], Any]) -> None:
+    with pytest.raises(RuntimeError, match="pipeline failed"):
+        runner(_pipeline_with_masked_error())
+
+
+def test_run_ignores_cleanup_error() -> None:
+    run(_pipeline_with_cleanup_error())
+
+
+def test_run_and_return_first_ignores_cleanup_error() -> None:
+    assert run_and_return_first(_pipeline_with_cleanup_error()) == "result"
+
+
+def test_run_and_collect_all_ignores_cleanup_error() -> None:
+    assert run_and_collect_all(_pipeline_with_cleanup_error()) == ["result"]
+
+
+def test_run_and_return_first_does_not_ignore_error_before_result() -> None:
+    def pipeline() -> Iterator[str]:
+        yield from ()
+        raise ValueError("Invalid thread ID 123")
+
+    with pytest.raises(ValueError, match="Invalid thread ID"):
+        run_and_return_first(pipeline())


### PR DESCRIPTION
The integration matrix can fail for reasons unrelated to the change under test: the clean-ZooKeeper scenario restores data while ClickHouse's replication queue can concurrently attach the same part, and a `stopit` cleanup error can hide the original pipeline exception.

This change keeps the clean-metadata scenario focused on replica metadata by using an empty table. It also restores a pipeline exception from `ValueError.__context__` when `stopit` raises `Invalid thread ID`, and covers both fetching the first result and exhausting the iterator with the same handler.

Regression tests cover masked pipeline errors, standalone cleanup errors, and an error raised before the first result.

Validation: `git diff --check`. Tests were not run.

## Summary by Sourcery

Make restore pipeline tests reliable by preserving meaningful failures and isolating clean-metadata restore behavior.

Bug Fixes:
- Restore the original pipeline exception when cleanup errors from stopit would otherwise mask it.
- Prevent run_and_return_first from suppressing invalid-thread cleanup errors when no result was fetched.

Enhancements:
- Keep the clean-metadata replicated-table restore scenario focused on replica metadata by using an empty table.

Tests:
- Add regression coverage for masked pipeline errors, standalone cleanup errors, and failures before the first result.