### PR TITLE
fix(deps): bump urllib3 2.4.0 -> 2.7.0 (CVE-2026-21441)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1106,11 +1106,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.4.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672, upload-time = "2025-04-10T15:23:39.232Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680, upload-time = "2025-04-10T15:23:37.377Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #355.

## Problem
`urllib3` versions before 2.6.3 decompress entire redirect response bodies even when streaming with `preload_content=False`, creating a decompression-bomb risk (CVE-2026-21441). The `uv.lock` pins urllib3 2.4.0 (a transitive dependency of `requests`/boto3).

## Change
Upgraded the transitive `urllib3` pin in `uv.lock` from 2.4.0 to 2.7.0 (via `uv lock --upgrade-package urllib3`).

## Verification
- `uv sync` resolves cleanly (urllib3 2.7.0 installed).
- Unit tests: 343 passed.

## Summary by Sourcery

Upgrade urllib3 to mitigate CVE-2026-21441 and secure dependency resolution.

Bug Fixes:
- Update the pinned urllib3 dependency to 2.7.0 to address a decompression-bomb vulnerability in older versions.

Build:
- Refresh the uv lockfile with the secure urllib3 version.

<!-- Generated by sourcery-ai[bot]: start fixed-security -->
- Resolves 4/6 issues in [urllib3](https://app.sourcery.ai/dashboard/security/issues?groupId=5805952&issueIds=10099134,10099136,11463357,53213094)
<!-- Generated by sourcery-ai[bot]: end fixed-security -->